### PR TITLE
fix(infra): docker-compose enxuto, sem service+db duplicados

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-SERVICE_URL=http://localhost:8080/api/v1
+SERVICE_URL=http://host.docker.internal:8080/api/v1
 NEXT_PUBLIC_API_URL=http://localhost:8080/api/v1
 LOGIN_REDIRECT_URL=http://127.0.0.1:3000
 GITHUB_CLIENT_ID=

--- a/README.md
+++ b/README.md
@@ -43,21 +43,35 @@ Make sure to set the URL for your backend API.
 
 ## Running with Docker (recommended)
 
-### 1) Subir Containers
+> O compose do Front sobe **somente o serviço `front`**. Backend (Service + Postgres) é responsabilidade do compose do repositório [`2026.1-MeasureSoftGram-Service`](https://github.com/fga-eps-mds/2026.1-MeasureSoftGram-Service) — suba lá primeiro.
+
+### 1) Subir o Service (em outro terminal, no repo do Service)
+
+```bash
+cd ../2026.1-MeasureSoftGram-Service
+cp -R env-vars-example env-vars   # primeiro setup
+docker compose up -d
+```
+
+API disponível em http://localhost:8080.
+
+### 2) Subir o Front
 
 ```bash
 docker compose up --build
 ```
 
-Aplicação disponível em http://localhost:3000
+Aplicação disponível em http://localhost:3000.
 
-### 2) Parar containers
+> No container do Front, `SERVICE_URL` aponta para `http://host.docker.internal:8080` para acessar o Service rodando no host. No browser, `NEXT_PUBLIC_API_URL` segue como `http://localhost:8080`.
+
+### 3) Parar containers
 
 ```bash
 docker compose down
 ```
 
-### 3) Scripts Úteis
+### 4) Scripts Úteis
 
 - Rodar linter:
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,39 +10,7 @@ services:
       - .:/usr/src/
       - /usr/src/node_modules
       - /usr/src/.next
-    depends_on:
-      - service
-
-  service:
-    container_name: msgram-service
-    image: joaoseisei1/msgram-service:1.0
-    command: ["./start_service.sh"]
-    restart: on-failure
-    ports:
-      - "8080:8080"
     env_file:
-      - ./env-vars/.service.env
-      - ./env-vars/.postgres.env
-    depends_on:
-      db:
-        condition: service_healthy
-
-  db:
-    container_name: msgram-postgres
-    image: postgres:15-alpine
-    restart: always
-    ports:
-      - "5432:5432"
-    volumes:
-      - service_postgres_data:/var/lib/postgresql/data
-    env_file:
-      - ./env-vars/.postgres.env
-    healthcheck:
-      test: ["CMD", "pg_isready", "-q", "-d", "postgres", "-U", "postgres"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 30s
-
-volumes:
-  service_postgres_data:
+      - .env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
## Descrição

Resolve o conflito de portas que aparece ao subir o Front e o Service simultaneamente em docker.

**Diagnóstico** (a partir da thread do Clã WEB de 26/04 noite):
- O `docker-compose.yml` do Front declarava 3 services (`front` + `service` + `db`).
- Após o merge do PR [#1 do repo Service](https://github.com/fga-eps-mds/2026.1-MeasureSoftGram-Service/pull/1), o Service também sobe seu próprio `db`.
- Ambos os composes expunham Postgres em `5432:5432` no host → conflito de porta.
- Container chamado `db` em ambos → conflito de nome.
- Versões divergentes: Front usava `postgres:15-alpine`, Service usa `postgres:18-alpine`.

## Mudanças

- `docker-compose.yml`: deixa apenas o serviço `front`. Remove `service` + `db` + volume `service_postgres_data`. Adiciona `extra_hosts: host.docker.internal:host-gateway` para suportar Linux. Mantém build context, `volumes`, port mapping e `env_file`.
- `.env.example`: `SERVICE_URL` aponta para `http://host.docker.internal:8080/api/v1` (server-side, dentro do container Front). `NEXT_PUBLIC_API_URL` segue em `http://localhost:8080/api/v1` (browser do usuário).
- `README.md`: novo passo 1 explicando que o Service precisa subir antes (no repo `2026.1-MeasureSoftGram-Service`). Numeração de seções ajustada (1) Service → 2) Front → 3) Parar → 4) Scripts).

Backend (Service + Postgres) passa a ser responsabilidade do compose do Service. Front fica enxuto e independente.

## Validação local

```bash
# terminal 1 (no repo Service)
cp -R env-vars-example env-vars
docker compose up -d
# terminal 2 (no repo Front)
docker compose up --build
```

Resultado:
- Service: `db` + `service` UP, sem conflito.
- Front: `front` UP em `http://localhost:3000` (HTTP 200).
- Container `front` alcança o Service via `host.docker.internal:8080`.

## Observação (não bloqueia este PR)

Em chamadas server-side do Next.js, o Django do Service responde `HTTP 400 Invalid HTTP_HOST header` porque `host.docker.internal` não está em `ALLOWED_HOSTS`. Não é regressão — é um gap pré-existente do Service (`ALLOWED_HOSTS` não está declarado em `src/config/settings.py`). Páginas client-side funcionam normalmente porque o browser usa `NEXT_PUBLIC_API_URL=http://localhost:8080`. Vale um PR de uma linha no Service:

```python
ALLOWED_HOSTS = ["*"] if DEBUG else os.getenv("ALLOWED_HOSTS", "").split(",")
```

Posso abrir esse PR no Service na sequência se o time concordar.

## Contexto

Levantado a partir da thread do Clã WEB no MSGram em 26/04 (Danilo + Raquel + Pierre debatendo o conflito). Solução combinada na thread.