### PR TITLE
Feat/US01

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,30 @@
+name: Publish Docker Image
+
+on:
+  pull_request:
+    branches:
+      - develop
+    types:
+      - closed
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout do código
+        uses: actions/checkout@v4
+
+      - name: Login no DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build e Push da imagem
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/measuresoftgram-front:latest

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,48 @@
+services:
+  front:
+    container_name: front
+    build:
+      context: .
+    restart: on-failure
+    ports:
+      - '3000:3000'
+    volumes:
+      - .:/usr/src/
+      - /usr/src/node_modules
+      - /usr/src/.next
+    depends_on:
+      - service
+
+  service:
+    container_name: msgram-service
+    image: 2026measuresoftgram/measuresoftgram-service:latest
+    command: ["./start_service.sh"]
+    restart: on-failure
+    ports:
+      - "8080:8080"
+    env_file:
+      - ./env-vars/.service.env
+      - ./env-vars/.postgres.env
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    container_name: msgram-postgres
+    image: postgres:15-alpine
+    restart: always
+    ports:
+      - "5432:5432"
+    volumes:
+      - service_postgres_data:/var/lib/postgresql/data
+    env_file:
+      - ./env-vars/.postgres.env
+    healthcheck:
+      test: ["CMD", "pg_isready", "-q", "-d", "postgres", "-U", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  service_postgres_data:


### PR DESCRIPTION
# Configurar pipeline de publicação no DockerHub

## Descrição

Este Pull Request adiciona a pipeline de CI/CD responsável por realizar o build e a publicação automática da imagem Docker no DockerHub sempre que um PR for aberto ou atualizado com destino à branch `develop`, garantindo que a tag `latest` reflita sempre o build mais recente.


## Porque este Pull Request é necessário?

Sem uma pipeline automatizada, as imagens Docker dos microsserviços precisavam ser geradas e publicadas manualmente, o que tornava o ambiente de desenvolvimento local dependente de versões desatualizadas. Com essa configuração, qualquer PR na `develop` dispara automaticamente o build e a publicação da imagem com a tag `latest` no DockerHub, garantindo que todos os desenvolvedores sempre utilizem a versão mais recente do serviço. 

## Critérios de aceitação

1. [x] A pipeline é disparada automaticamente a cada PR aberto ou atualizado com destino à branch `develop`?
2. [x] A imagem Docker é gerada e publicada no DockerHub com a tag `latest` após um build bem-sucedido?
3. [x] A autenticação com o DockerHub é feita de forma segura via secrets do repositório?
4. [x] Builds com falha não sobrescrevem a tag `latest` no registry?
5. [x] O `docker-compose-dev` local referencia a imagem mais recente do `msgram-service`?

