### PR TITLE
feat: adiciona nova badge TSQMI nas páginas de repositório

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest src/ --watch --coverage --verbose --onlyChanged --passWithNoTests",
-    "ci:test": "jest --passWithNoTests",
+    "test": "TZ=America/Sao_Paulo jest src/ --watch --coverage --verbose --onlyChanged --passWithNoTests",
+    "ci:test": "TZ=America/Sao_Paulo jest --passWithNoTests",
     "prettier": "prettier --config .prettierrc 'src/**/*.ts' --write",
-    "update-snapshot": "jest --updateSnapshot"
+    "update-snapshot": "TZ=America/Sao_Paulo jest --updateSnapshot"
   },
   "dependencies": {
     "@emotion/react": "^11.9.3",

--- a/public/locales/en/repositories.json
+++ b/public/locales/en/repositories.json
@@ -50,6 +50,8 @@
     "badge-instructions": "Paste the code below in your repository's README:",
     "badge-cancel": "Cancel",
     "badge-copy-btn": "Copy",
+    "badge-copy-error": "Failed to copy to clipboard.",
+    "badge-stale": "The last analysis was performed more than 30 days ago. The badge may be outdated.",
     "badge-error": "An error occurred while loading badge information."
   }
 }

--- a/public/locales/en/repositories.json
+++ b/public/locales/en/repositories.json
@@ -43,6 +43,13 @@
     "measure": "Measures",
     "measure-history": "Measures History",
     "measure-scenario": "Current Measures Scenario",
-    "metrics": "Metrics"
+    "metrics": "Metrics",
+    "badge-tooltip": "Repository quality",
+    "copy-badge": "Copy Badge",
+    "badge-copied": "Badge copied successfully!",
+    "badge-instructions": "Paste the code below in your repository's README:",
+    "badge-cancel": "Cancel",
+    "badge-copy-btn": "Copy",
+    "badge-error": "An error occurred while loading badge information."
   }
 }

--- a/public/locales/pt/repositories.json
+++ b/public/locales/pt/repositories.json
@@ -43,6 +43,13 @@
     "measure": "Medidas",
     "measure-history": "Histórico de Medidas",
     "measure-scenario": "Cenário atual das Medidas",
-    "metrics": "Métricas"
+    "metrics": "Métricas",
+    "badge-tooltip": "Qualidade do repositório",
+    "copy-badge": "Copiar Badge",
+    "badge-copied": "Badge copiada com sucesso!",
+    "badge-instructions": "Cole o código abaixo no README do seu repositório:",
+    "badge-cancel": "Cancelar",
+    "badge-copy-btn": "Copiar",
+    "badge-error": "Ocorreu um erro ao tentar carregar as informações da badge."
   }
 }

--- a/public/locales/pt/repositories.json
+++ b/public/locales/pt/repositories.json
@@ -50,6 +50,8 @@
     "badge-instructions": "Cole o código abaixo no README do seu repositório:",
     "badge-cancel": "Cancelar",
     "badge-copy-btn": "Copiar",
+    "badge-copy-error": "Falha ao copiar para a área de transferência.",
+    "badge-stale": "A última análise foi realizada há mais de 30 dias. A badge pode estar desatualizada.",
     "badge-error": "Ocorreu um erro ao tentar carregar as informações da badge."
   }
 }

--- a/src/pages/products/[product]/components/RepositoriesList/RepositoriesTable/RepositoriesTable.tsx
+++ b/src/pages/products/[product]/components/RepositoriesList/RepositoriesTable/RepositoriesTable.tsx
@@ -19,6 +19,7 @@ import TsqmiBadge from '@pages/products/[product]/repositories/[repository]/comp
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@hooks/useQuery';
 import { productQuery } from '@services/product';
+import { repository as repositoryService } from '@services/repository';
 import { getPathId } from '@utils/pathDestructer';
 
 interface Props {
@@ -87,9 +88,15 @@ const RepositoriesTable: React.FC<Props> = ({ maxCount }: Props) => {
 
   const getTsqmiValue = (id: number) => repositoriesLatestTsqmi?.results.find(result => result.id === id)?.current_tsqmi
 
-  const getTsqmiUrl = (id: number) => (
-    `${repositoriesLatestTsqmi?.results.find(result => result.id === id)?.url}badge`
-  )
+  const getTsqmiUrl = (repoId: number) => {
+    const [organizationId, productId] = getPathId(router.query?.product as string);
+    return repositoryService.getTsqmiBadgeUrl({
+      organizationId,
+      productId,
+      repositoryId: String(repoId),
+      entity: 'tsqmi'
+    });
+  }
 
   function handleRepositoriesFilter(name: string) {
     if ((name == null || name === '') && repositoryList?.length) {
@@ -192,6 +199,7 @@ const RepositoriesTable: React.FC<Props> = ({ maxCount }: Props) => {
                 <TsqmiBadge
                   latestTSQMI={getTsqmiValue(repo.id)}
                   latestTSQMIBadgeUrl={getTsqmiUrl(repo.id)}
+                  showCopyButton={false}
                 />
               </TableCell>
               <TableCell align="right">

--- a/src/pages/products/[product]/repositories/[repository]/components/CopyBadgeModal/CopyBadgeModal.tsx
+++ b/src/pages/products/[product]/repositories/[repository]/components/CopyBadgeModal/CopyBadgeModal.tsx
@@ -1,13 +1,15 @@
 import { useRepositoryContext } from '@contexts/RepositoryProvider';
-import { Alert, Box, Button, IconButton, Modal, Typography } from '@mui/material';
+import { Alert, Box, Button, IconButton, Modal, Tooltip, Typography } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
 import React, { useState } from 'react';
 import { toast } from 'react-toastify';
+import { useTranslation } from 'react-i18next';
 
 
 function CopyBadgeModal() {
   const { latestTSQMIBadgeUrl } = useRepositoryContext();
+  const { t } = useTranslation('repositories');
 
   const [openModal, setOpenModal] = useState<boolean>(false);
 
@@ -19,17 +21,21 @@ function CopyBadgeModal() {
     setOpenModal(false);
   };
 
+  const badgeMarkdown = `![MeasureSoftGram](${latestTSQMIBadgeUrl})`;
+
   const copyToClipboard = () => {
-    navigator.clipboard.writeText(`![TSQMI Rating](${latestTSQMIBadgeUrl})`);
+    navigator.clipboard.writeText(badgeMarkdown);
     handleCloseModal();
-    toast.success('Copiado com sucesso!');
+    toast.success(t('repository.badge-copied', 'Badge copiada com sucesso!'));
   }
 
   return (
     <>
-      <IconButton onClick={handleOpenModal}>
-        <ContentCopyIcon />
-      </IconButton>
+      <Tooltip title={t('repository.copy-badge', 'Copiar Badge')} placement="top">
+        <IconButton onClick={handleOpenModal} size="small">
+          <ContentCopyIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
 
       <Modal
         open={openModal}
@@ -48,21 +54,29 @@ function CopyBadgeModal() {
           }}
         >
           <Typography variant="h6" gutterBottom>
-            Copiar Badge
+            {t('repository.copy-badge', 'Copiar Badge')}
           </Typography>
           {
             latestTSQMIBadgeUrl ?
               <>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                  {t('repository.badge-instructions', 'Cole o código abaixo no README do seu repositório:')}
+                </Typography>
                 <Box
                   sx={{
                     backgroundColor: '#E9E9E9',
                     borderRadius: 1,
                     p: 2,
                     wordBreak: 'break-word',
-                    marginBottom: '10px'
+                    marginBottom: '10px',
+                    fontFamily: 'monospace',
+                    fontSize: '0.85rem',
                   }}
                 >
-                  ![TSQMI Rating]({latestTSQMIBadgeUrl})
+                  {badgeMarkdown}
+                </Box>
+                <Box display="flex" justifyContent="center" mb={2}>
+                  <img src={latestTSQMIBadgeUrl} alt="Badge Preview" style={{ height: '20px' }} />
                 </Box>
                 <Box
                   display="flex"
@@ -74,20 +88,20 @@ function CopyBadgeModal() {
                     onClick={handleCloseModal}
                     variant='outlined'
                   >
-                    Cancelar
+                    {t('repository.badge-cancel', 'Cancelar')}
                   </Button>
                   <Button
                     variant='contained'
                     onClick={copyToClipboard}
+                    startIcon={<ContentCopyIcon />}
                   >
-                    <ContentCopyIcon />
-                    Copiar
+                    {t('repository.badge-copy-btn', 'Copiar')}
                   </Button>
                 </Box>
               </>
               :
               <Alert sx={{ display: "flex", justifyContent: "center", textAlign: 'center' }} severity="error">
-                Ocorreu um erro ao tentar carregar as informações.
+                {t('repository.badge-error', 'Ocorreu um erro ao tentar carregar as informações.')}
               </Alert>
           }
 

--- a/src/pages/products/[product]/repositories/[repository]/components/CopyBadgeModal/CopyBadgeModal.tsx
+++ b/src/pages/products/[product]/repositories/[repository]/components/CopyBadgeModal/CopyBadgeModal.tsx
@@ -24,9 +24,14 @@ function CopyBadgeModal() {
   const badgeMarkdown = `![MeasureSoftGram](${latestTSQMIBadgeUrl})`;
 
   const copyToClipboard = () => {
-    navigator.clipboard.writeText(badgeMarkdown);
-    handleCloseModal();
-    toast.success(t('repository.badge-copied', 'Badge copiada com sucesso!'));
+    navigator.clipboard.writeText(badgeMarkdown)
+      .then(() => {
+        handleCloseModal();
+        toast.success(t('repository.badge-copied', 'Badge copiada com sucesso!'));
+      })
+      .catch(() => {
+        toast.error(t('repository.badge-copy-error', 'Falha ao copiar para a área de transferência.'));
+      });
   }
 
   return (

--- a/src/pages/products/[product]/repositories/[repository]/components/CopyBadgeModal/tests/CopyBadgeModal.spec.tsx
+++ b/src/pages/products/[product]/repositories/[repository]/components/CopyBadgeModal/tests/CopyBadgeModal.spec.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { toast } from 'react-toastify';
+import CopyBadgeModal from '../CopyBadgeModal';
+
+
+const mockBadgeUrl = 'http://localhost:8000/organizations/1/products/1/repositories/1/latest-values/tsqmi/badge';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback: string) => fallback
+  })
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+const mockUseRepositoryContext = jest.fn();
+jest.mock('@contexts/RepositoryProvider', () => ({
+  useRepositoryContext: () => mockUseRepositoryContext()
+}));
+
+describe('<CopyBadgeModal />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRepositoryContext.mockReturnValue({
+      latestTSQMIBadgeUrl: mockBadgeUrl
+    });
+  });
+
+  it('should render the copy icon button', () => {
+    render(<CopyBadgeModal />);
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+  });
+
+  it('should open modal when copy button is clicked', () => {
+    render(<CopyBadgeModal />);
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+
+    expect(screen.getByText('Copiar Badge')).toBeInTheDocument();
+    expect(screen.getByText('Cole o código abaixo no README do seu repositório:')).toBeInTheDocument();
+  });
+
+  it('should display the markdown code in the modal', () => {
+    render(<CopyBadgeModal />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText(`![MeasureSoftGram](${mockBadgeUrl})`)).toBeInTheDocument();
+  });
+
+  it('should display badge preview image in the modal', () => {
+    render(<CopyBadgeModal />);
+    fireEvent.click(screen.getByRole('button'));
+
+    const img = screen.getByAltText('Badge Preview');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', mockBadgeUrl);
+  });
+
+  it('should copy markdown to clipboard and show success toast', async () => {
+    const writeTextMock = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: { writeText: writeTextMock }
+    });
+
+    render(<CopyBadgeModal />);
+    fireEvent.click(screen.getByRole('button'));
+
+    const copyButton = screen.getByText('Copiar');
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(`![MeasureSoftGram](${mockBadgeUrl})`);
+      expect(toast.success).toHaveBeenCalledWith('Badge copiada com sucesso!');
+    });
+  });
+
+  it('should show error toast when clipboard write fails', async () => {
+    const writeTextMock = jest.fn().mockRejectedValue(new Error('Permission denied'));
+    Object.assign(navigator, {
+      clipboard: { writeText: writeTextMock }
+    });
+
+    render(<CopyBadgeModal />);
+    fireEvent.click(screen.getByRole('button'));
+
+    const copyButton = screen.getByText('Copiar');
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Falha ao copiar para a área de transferência.');
+    });
+  });
+
+  it('should show error alert when latestTSQMIBadgeUrl is not available', () => {
+    mockUseRepositoryContext.mockReturnValue({
+      latestTSQMIBadgeUrl: ''
+    });
+
+    render(<CopyBadgeModal />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('Ocorreu um erro ao tentar carregar as informações.')).toBeInTheDocument();
+  });
+
+  it('should close modal when cancel button is clicked', async () => {
+    render(<CopyBadgeModal />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('Copiar Badge')).toBeInTheDocument();
+
+    const cancelButton = screen.getByText('Cancelar');
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Cole o código abaixo no README do seu repositório:')).not.toBeInTheDocument();
+    });
+  });
+});
+
+
+

--- a/src/pages/products/[product]/repositories/[repository]/components/Header/tests/__snapshots__/Header.spec.tsx.snap
+++ b/src/pages/products/[product]/repositories/[repository]/components/Header/tests/__snapshots__/Header.spec.tsx.snap
@@ -48,13 +48,15 @@ exports[`Header should render correctly 1`] = `
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+        aria-label="Copiar Badge"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
+        data-mui-internal-clone-element="true"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
           data-testid="ContentCopyIcon"
           focusable="false"
           viewBox="0 0 24 24"

--- a/src/pages/products/[product]/repositories/[repository]/components/TsqmiBadge/TsqmiBadge.tsx
+++ b/src/pages/products/[product]/repositories/[repository]/components/TsqmiBadge/TsqmiBadge.tsx
@@ -1,89 +1,41 @@
 import { Box, Tooltip } from '@mui/material';
 
-import React, { useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { TsqmiValue } from '@customTypes/product';
-
-const oneStarBadge = '/images/svg/badges/1stars.svg';
-const twoStarBadge = '/images/svg/badges/2stars.svg';
-const threeStarBadge = '/images/svg/badges/3stars.svg';
-const fourStarBadge = '/images/svg/badges/4stars.svg';
-const fiveStarBadge = '/images/svg/badges/5stars.svg';
-const zeroStarBadge = '/images/svg/badges/0stars.svg';
+import CopyBadgeModal from '../CopyBadgeModal';
 
 interface TsqmiBadgeProps {
   latestTSQMI: TsqmiValue;
   latestTSQMIBadgeUrl: string;
+  showCopyButton?: boolean;
 }
 
-function TsqmiBadge({ latestTSQMI, latestTSQMIBadgeUrl }: TsqmiBadgeProps) {
-  const [showBadge, setShowBadge] = useState<boolean>(false);
-  const [badgePath, setBadgePath] = useState<any>('');
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function TsqmiBadge({ latestTSQMI, latestTSQMIBadgeUrl, showCopyButton = true }: TsqmiBadgeProps) {
+  const { t } = useTranslation('repositories');
 
-  useEffect(() => {
-    setStars();
-  }, [latestTSQMI])
-
-  const setStars = () => {
-    let star: any;
-
-    if (latestTSQMI) {
-      const { value } = latestTSQMI;
-
-      switch (true) {
-        case value === 0:
-          star = zeroStarBadge;
-          break;
-        case value > 0 && value < 0.2:
-          star = oneStarBadge;
-          break;
-        case value >= 0.2 && value < 0.4:
-          star = twoStarBadge;
-          break;
-        case value >= 0.4 && value < 0.6:
-          star = threeStarBadge;
-          break;
-        case value >= 0.6 && value < 0.8:
-          star = fourStarBadge;
-          break;
-        case value >= 0.8 && value <= 1.0:
-          star = fiveStarBadge;
-          break;
-        default:
-          star = null;
-      }
-    }
-
-    if (star) {
-      setBadgePath(star)
-      setShowBadge(true);
-    }
+  if (!latestTSQMIBadgeUrl) {
+    return null;
   }
 
-  const copyToClipboard = () => {
-    navigator.clipboard.writeText(`![TSQMI Rating](${latestTSQMIBadgeUrl})`);
-    toast.success('Copiado com sucesso!');
-  }
   return (
-    <>
-      {showBadge &&
-        <Tooltip title="Copiar para área de transferência" placement="bottom">
-          <Box
-            display="flex"
-            justifyContent="center"
-            sx={{
-              ':hover': {
-                cursor: 'pointer',
-              }
-            }}
-            onClick={copyToClipboard}
-          >
-            <img src={badgePath} alt="Exemplo SVG" style={{ width: '120px', height: '25px' }} />
-          </Box>
-        </Tooltip>
-      }
-      <div />
-    </>
+    <Box
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      gap="8px"
+      marginY="16px"
+    >
+      <Tooltip title={t('repository.badge-tooltip', 'Qualidade do repositório')} placement="bottom">
+        <img
+          src={latestTSQMIBadgeUrl}
+          alt="TSQMI Badge"
+          style={{ width: '158px', height: '20px' }}
+        />
+      </Tooltip>
+      {showCopyButton && <CopyBadgeModal />}
+    </Box>
   );
 }
 

--- a/src/pages/products/[product]/repositories/[repository]/components/TsqmiBadge/TsqmiBadge.tsx
+++ b/src/pages/products/[product]/repositories/[repository]/components/TsqmiBadge/TsqmiBadge.tsx
@@ -1,9 +1,11 @@
-import { Box, Tooltip } from '@mui/material';
+import { Alert, Box, Tooltip } from '@mui/material';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TsqmiValue } from '@customTypes/product';
 import CopyBadgeModal from '../CopyBadgeModal';
+
+const BADGE_STALENESS_DAYS = 30;
 
 interface TsqmiBadgeProps {
   latestTSQMI: TsqmiValue;
@@ -11,9 +13,16 @@ interface TsqmiBadgeProps {
   showCopyButton?: boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function TsqmiBadge({ latestTSQMI, latestTSQMIBadgeUrl, showCopyButton = true }: TsqmiBadgeProps) {
   const { t } = useTranslation('repositories');
+
+  const isStale = useMemo(() => {
+    if (!latestTSQMI?.created_at) return true;
+    const createdAt = new Date(latestTSQMI.created_at).getTime();
+    const now = Date.now();
+    const diffDays = (now - createdAt) / (1000 * 60 * 60 * 24);
+    return diffDays > BADGE_STALENESS_DAYS;
+  }, [latestTSQMI]);
 
   if (!latestTSQMIBadgeUrl) {
     return null;
@@ -22,19 +31,26 @@ function TsqmiBadge({ latestTSQMI, latestTSQMIBadgeUrl, showCopyButton = true }:
   return (
     <Box
       display="flex"
+      flexDirection="column"
       alignItems="center"
-      justifyContent="center"
       gap="8px"
       marginY="16px"
     >
-      <Tooltip title={t('repository.badge-tooltip', 'Qualidade do repositório')} placement="bottom">
-        <img
-          src={latestTSQMIBadgeUrl}
-          alt="TSQMI Badge"
-          style={{ width: '158px', height: '20px' }}
-        />
-      </Tooltip>
-      {showCopyButton && <CopyBadgeModal />}
+      <Box display="flex" alignItems="center" gap="8px">
+        <Tooltip title={t('repository.badge-tooltip', 'Qualidade do repositório')} placement="bottom">
+          <img
+            src={latestTSQMIBadgeUrl}
+            alt="TSQMI Badge"
+            style={{ width: '158px', height: '20px' }}
+          />
+        </Tooltip>
+        {showCopyButton && <CopyBadgeModal />}
+      </Box>
+      {isStale && (
+        <Alert severity="warning" sx={{ fontSize: '0.75rem', py: 0, px: 1 }}>
+          {t('repository.badge-stale', 'A última análise foi realizada há mais de 30 dias. A badge pode estar desatualizada.')}
+        </Alert>
+      )}
     </Box>
   );
 }

--- a/src/pages/products/[product]/repositories/[repository]/components/TsqmiBadge/tests/TsqmiBadge.spec.tsx
+++ b/src/pages/products/[product]/repositories/[repository]/components/TsqmiBadge/tests/TsqmiBadge.spec.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TsqmiBadge from '../TsqmiBadge';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback: string) => fallback
+  })
+}));
+
+jest.mock('../../CopyBadgeModal', () => ({
+  __esModule: true,
+  default: () => <div data-testid="copy-badge-modal" />
+}));
+
+const mockLatestTSQMI = {
+  id: 1,
+  value: 0.75,
+  created_at: '2026-05-20T00:00:00Z'
+};
+
+const mockBadgeUrl = 'http://localhost:8000/organizations/1/products/1/repositories/1/latest-values/tsqmi/badge';
+const STALE_WARNING_TEXT = 'A última análise foi realizada há mais de 30 dias. A badge pode estar desatualizada.';
+
+describe('<TsqmiBadge />', () => {
+  it('should render the badge image when latestTSQMIBadgeUrl is provided', () => {
+    render(
+      <TsqmiBadge
+        latestTSQMI={mockLatestTSQMI}
+        latestTSQMIBadgeUrl={mockBadgeUrl}
+      />
+    );
+
+    const img = screen.getByAltText('TSQMI Badge');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', mockBadgeUrl);
+  });
+
+  it('should return null when latestTSQMIBadgeUrl is empty', () => {
+    const { container } = render(
+      <TsqmiBadge
+        latestTSQMI={mockLatestTSQMI}
+        latestTSQMIBadgeUrl=""
+      />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should show CopyBadgeModal by default (showCopyButton=true)', () => {
+    render(
+      <TsqmiBadge
+        latestTSQMI={mockLatestTSQMI}
+        latestTSQMIBadgeUrl={mockBadgeUrl}
+      />
+    );
+
+    expect(screen.getByTestId('copy-badge-modal')).toBeInTheDocument();
+  });
+
+  it('should hide CopyBadgeModal when showCopyButton=false', () => {
+    render(
+      <TsqmiBadge
+        latestTSQMI={mockLatestTSQMI}
+        latestTSQMIBadgeUrl={mockBadgeUrl}
+        showCopyButton={false}
+      />
+    );
+
+    expect(screen.queryByTestId('copy-badge-modal')).not.toBeInTheDocument();
+  });
+
+  it('should show stale warning when analysis is older than 30 days', () => {
+    const staleTSQMI = {
+      id: 1,
+      value: 0.75,
+      created_at: '2026-03-01T00:00:00Z' // more than 30 days ago
+    };
+
+    render(
+      <TsqmiBadge
+        latestTSQMI={staleTSQMI}
+        latestTSQMIBadgeUrl={mockBadgeUrl}
+      />
+    );
+
+    expect(screen.getByText(STALE_WARNING_TEXT)).toBeInTheDocument();
+  });
+
+  it('should not show stale warning when analysis is recent', () => {
+    const recentTSQMI = {
+      id: 1,
+      value: 0.75,
+      created_at: new Date().toISOString() // today
+    };
+
+    render(
+      <TsqmiBadge
+        latestTSQMI={recentTSQMI}
+        latestTSQMIBadgeUrl={mockBadgeUrl}
+      />
+    );
+
+    expect(screen.queryByText(STALE_WARNING_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('should show stale warning when latestTSQMI is null', () => {
+    render(
+      <TsqmiBadge
+        latestTSQMI={null}
+        latestTSQMIBadgeUrl={mockBadgeUrl}
+      />
+    );
+
+    expect(screen.getByText(STALE_WARNING_TEXT)).toBeInTheDocument();
+  });
+});

--- a/src/pages/products/[product]/repositories/[repository]/tests/Repository.spec.tsx
+++ b/src/pages/products/[product]/repositories/[repository]/tests/Repository.spec.tsx
@@ -13,7 +13,10 @@ jest.mock('@contexts/ProductProvider', () => ({
 }));
 
 jest.mock('@contexts/RepositoryProvider', () => ({
-  useRepositoryContext: () => ({})
+  useRepositoryContext: () => ({
+    latestTSQMI: { id: 1, value: 0.75, created_at: '2026-05-20T00:00:00Z' },
+    latestTSQMIBadgeUrl: 'http://localhost:8000/organizations/1/products/1/repositories/1/latest-values/tsqmi/badge'
+  })
 }));
 
 jest.mock('next/router', () => ({

--- a/src/pages/products/[product]/repositories/[repository]/tests/__snapshots__/Repository.spec.tsx.snap
+++ b/src/pages/products/[product]/repositories/[repository]/tests/__snapshots__/Repository.spec.tsx.snap
@@ -57,13 +57,15 @@ exports[`<Repository /> Should render correctly 1`] = `
               />
             </button>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+              aria-label="Copiar Badge"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
               tabindex="0"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
                 data-testid="ContentCopyIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -78,7 +80,44 @@ exports[`<Repository /> Should render correctly 1`] = `
             </button>
           </div>
         </div>
-        <div />
+        <div
+          class="MuiBox-root css-16cy4gl"
+        >
+          <div
+            class="MuiBox-root css-axw7ok"
+          >
+            <img
+              alt="TSQMI Badge"
+              aria-label="Qualidade do repositório"
+              class=""
+              data-mui-internal-clone-element="true"
+              src="http://localhost:8000/organizations/1/products/1/repositories/1/latest-values/tsqmi/badge"
+              style="width: 158px; height: 20px;"
+            />
+            <button
+              aria-label="Copiar Badge"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                data-testid="ContentCopyIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2m0 16H8V7h11z"
+                />
+              </svg>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+        </div>
         <div
           class="MuiBox-root css-1ntb6q6"
         >

--- a/src/shared/components/LatestValueTable/tests/__snapshots__/LatestValueTable.spec.tsx.snap
+++ b/src/shared/components/LatestValueTable/tests/__snapshots__/LatestValueTable.spec.tsx.snap
@@ -59,7 +59,7 @@ exports[`<LatestValueTable /> should render correctly 1`] = `
             <td
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeMedium css-15suxum-MuiTableCell-root"
             >
-              21/06/2023 22:42:39
+              21/06/2023 19:42:39
             </td>
           </tr>
           <tr
@@ -79,7 +79,7 @@ exports[`<LatestValueTable /> should render correctly 1`] = `
             <td
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-sizeMedium css-15suxum-MuiTableCell-root"
             >
-              21/06/2023 22:42:39
+              21/06/2023 19:42:39
             </td>
           </tr>
         </tbody>

--- a/src/shared/utils/tests/__snapshots__/formatCharacteristicsHistory.spec.tsx.snap
+++ b/src/shared/utils/tests/__snapshots__/formatCharacteristicsHistory.spec.tsx.snap
@@ -69,8 +69,8 @@ Object {
   "xAxis": Object {
     "boundaryGap": false,
     "data": Array [
-      "06/01/2023 00:40",
-      "06/01/2023 03:01",
+      "05/01/2023 21:40",
+      "06/01/2023 00:01",
     ],
     "show": true,
     "type": "category",

--- a/src/shared/utils/tests/__snapshots__/formatMsgramChart.spec.tsx.snap
+++ b/src/shared/utils/tests/__snapshots__/formatMsgramChart.spec.tsx.snap
@@ -144,7 +144,7 @@ Object {
   "xAxis": Array [
     Object {
       "data": Array [
-        "28/11/2023 00:53",
+        "27/11/2023 21:53",
       ],
       "gridIndex": 0,
       "show": false,
@@ -152,7 +152,7 @@ Object {
     },
     Object {
       "data": Array [
-        "28/11/2023 00:53",
+        "27/11/2023 21:53",
       ],
       "gridIndex": 1,
       "show": true,


### PR DESCRIPTION
## Motivação

Implementar a funcionalidade de badge Markdown com a nota de qualidade (TSQMI) do repositório, permitindo que desenvolvedores exibam a badge no README de seus repositórios. A badge é renderizada dinamicamente pelo backend como SVG, seguindo o esquema de notas A–E, e exibe "N/A" (cinza) quando a análise está expirada (>30 dias sem atualização).

## Mudanças

- Refatorado o componente TsqmiBadge para renderizar diretamente o SVG retornado pelo endpoint do backend
- Adicionada prop showCopyButton ao TsqmiBadge para controlar exibição do botão de cópia
- Integrado o componente CopyBadgeModal dentro do TsqmiBadge na página do repositório, com preview da badge e código - Markdown para cópia
- Atualizado CopyBadgeModal com suporte a i18n, preview visual da badge e instrução ao usuário
- Corrigido getTsqmiUrl na RepositoriesTable que construía a URL da badge incorretamente (usava URL do GitHub em vez da URL da API)
- Adicionadas chaves de tradução (PT/EN) para os textos relacionados à badge nos arquivos de locale

## Status Checklist

<!-- In the status section, you can mark what you have already done -->

- [ ] Test
- [ ] Lint
- [ ] Development

## Screenshots

| Before                                               | After                                                |
| ---------------------------------------------------- | ---------------------------------------------------- |
| <img width="1920" height="953" alt="image" src="https://github.com/user-attachments/assets/8abaae66-929f-4e41-b59d-f8a398a2a764" /> | <img width="1806" height="969" alt="image" src="https://github.com/user-attachments/assets/339aff83-788d-46b4-818e-42604ba0f72b" /> |
| <img width="1920" height="953" alt="image" src="https://github.com/user-attachments/assets/58fea6d0-bb84-45e3-8712-a7609a481f46" /> | <img width="1659" height="967" alt="image" src="https://github.com/user-attachments/assets/41960505-1ff5-4810-a975-2815e3431d26" /> |



## Execução

- Acesse a página de listagem de repositórios (/products/{orgId}-{productId}/repositories/) e verifique que a badge SVG aparece corretamente para cada repositório
- Acesse a página de um repositório específico (/products/{orgId}-{productId}/repositories/{repoId}-{repoName}) e verifique que a badge aparece com o botão de copiar ao lado
- Clique no ícone de copiar e verifique que o modal abre com o código Markdown e preview da badge
- Clique em "Copiar" e verifique que o texto é copiado para o clipboard
- Verifique que um repositório sem análise ou com análise expirada (>30 dias) exibe a badge cinza "N/A"
