### PR TITLE
fix(services/api): baseURL com NEXT_PUBLIC_API_URL pro client

### DIFF
--- a/src/shared/services/api.ts
+++ b/src/shared/services/api.ts
@@ -1,7 +1,10 @@
 import axios from 'axios';
 
+// NEXT_PUBLIC_API_URL e exposta ao client pelo Next; SERVICE_URL existe so
+// no server. Sem fallback, baseURL fica undefined no browser e calls caem
+// no proprio dominio do front (404).
 const api = axios.create({
-  baseURL: process.env.SERVICE_URL,
+  baseURL: process.env.NEXT_PUBLIC_API_URL || process.env.SERVICE_URL,
   withCredentials: true
 });
 

--- a/src/shared/services/tests/api.spec.ts
+++ b/src/shared/services/tests/api.spec.ts
@@ -121,3 +121,43 @@ describe('API Interceptors', () => {
     });
   });
 });
+
+describe('api client baseURL', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.NEXT_PUBLIC_API_URL;
+    delete process.env.SERVICE_URL;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('uses NEXT_PUBLIC_API_URL when defined (client-side exposed var)', () => {
+    process.env.NEXT_PUBLIC_API_URL = 'https://api.example.test/api/v1';
+
+    const api = require('../api').default;
+
+    expect(api.defaults.baseURL).toBe('https://api.example.test/api/v1');
+  });
+
+  it('falls back to SERVICE_URL when NEXT_PUBLIC_API_URL is absent', () => {
+    process.env.SERVICE_URL = 'https://service.example.test/api/v1';
+
+    const api = require('../api').default;
+
+    expect(api.defaults.baseURL).toBe('https://service.example.test/api/v1');
+  });
+
+  it('prefers NEXT_PUBLIC_API_URL over SERVICE_URL when both are set', () => {
+    process.env.NEXT_PUBLIC_API_URL = 'https://public.example.test/api/v1';
+    process.env.SERVICE_URL = 'https://service.example.test/api/v1';
+
+    const api = require('../api').default;
+
+    expect(api.defaults.baseURL).toBe('https://public.example.test/api/v1');
+  });
+});


### PR DESCRIPTION
## Resumo

O axios client em `src/shared/services/api.ts` usava apenas `process.env.SERVICE_URL` como `baseURL`. Variaveis sem prefixo `NEXT_PUBLIC_` nao sao expostas ao bundle do client pelo Next.js, entao no browser `baseURL` ficava `undefined` e chamadas como `api.post('/accounts/login/')` caiam no proprio dominio do front (404).

Fix: ler `NEXT_PUBLIC_API_URL` primeiro, com fallback para `SERVICE_URL` (compat com deploys existentes que so injetam a var no env do server).

Closes #34

## Commits

- `4140d3a` test(services/api): add failing tests for NEXT_PUBLIC_API_URL baseURL (RED)
- `b8b6813` fix(services/api): prefer NEXT_PUBLIC_API_URL over SERVICE_URL (GREEN)

## Test plan

- [x] `npx jest src/shared/services/tests/api.spec.ts` passa (3 testes).
- [x] Validado em HML (`msgram.synaptha.com`): login com email/senha agora bate em `https://msgram-api.synaptha.com/api/v1/accounts/login/` (400 = credencial invalida) em vez de cair no front (404).
- [ ] CI verde.