### PR TITLE
build(docker): Dockerfile de producao multistage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,31 @@
-/node_modules
-/.next/
+# dependencias e build local (instalados/gerados dentro da imagem)
+node_modules
+.next
+.swc
+
+# controle de versao e CI
+.git
+.gitignore
+.github
+
+# segredos e envs locais (NUNCA entram na imagem)
+.env
+.env.*
+.envs
+
+# cobertura e artefatos de teste
+coverage
+coverage.xml
+tests
+__mocks__
+
+# editores e SO
+.vscode
+.idea
+.DS_Store
+
+# docs e meta (nao precisam no build de runtime)
+*.md
+CLAUDE.md
+Makefile
+.eslintcache

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,10 @@ on:
 
 jobs:
   build-and-push:
+    # Imagem de producao buildada na nuvem (ubuntu-latest); a maquina de deploy
+    # apenas faz PULL desta imagem, nao builda.
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
 
     steps:
       - name: Checkout do código
@@ -27,4 +30,8 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          # SERVICE_URL e inlined no bundle em build-time (next.config.js).
+          # Trocar a URL exige rebuild da imagem.
+          build-args: |
+            SERVICE_URL=https://msgram.lappis.rocks/api
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/front:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,8 +30,18 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          # SERVICE_URL e inlined no bundle em build-time (next.config.js).
-          # Trocar a URL exige rebuild da imagem.
+          # SERVICE_URL, GITHUB_CLIENT_ID e LOGIN_REDIRECT_URL sao inlined no
+          # bundle em build-time (next.config.js bloco env:). GITHUB_CLIENT_ID e
+          # LOGIN_REDIRECT_URL sao lidos client-side em Auth.service.tsx pra
+          # montar a URL de OAuth do GitHub (client_id + redirect_uri); sem eles
+          # o login GitHub quebra na imagem publicada. Trocar qualquer um exige
+          # rebuild da imagem.
+          # NOTA: o secret NAO pode se chamar GITHUB_CLIENT_ID - o GitHub Actions
+          # reserva o prefixo GITHUB_ e recusa secrets/vars com esse nome. Por
+          # isso o secret e GH_OAUTH_CLIENT_ID, mas o build-arg que o Dockerfile
+          # le continua sendo GITHUB_CLIENT_ID.
           build-args: |
             SERVICE_URL=https://msgram.lappis.rocks/api
+            GITHUB_CLIENT_ID=${{ secrets.GH_OAUTH_CLIENT_ID }}
+            LOGIN_REDIRECT_URL=${{ secrets.LOGIN_REDIRECT_URL }}
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/front:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,9 @@ FROM base AS builder
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# build-args inlined no bundle (build-time). Default aponta pro /api atras do
-# proxy. Sobrescreva via --build-arg no CI conforme o ambiente.
-ARG SERVICE_URL=https://msgram.lappis.rocks/api
+# build-args inlined no bundle (build-time). O default e o ambiente de
+# desenvolvimento; o valor de cada ambiente vem via --build-arg no CI.
+ARG SERVICE_URL=http://localhost:8080/api/v1
 ARG LOGIN_REDIRECT_URL
 ARG GITHUB_CLIENT_ID
 ENV SERVICE_URL=$SERVICE_URL

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,82 @@
-FROM node:20-alpine
+# syntax=docker/dockerfile:1
 
-# Set environment
-ENV NODE_ENV=development
-ENV PORT=3000
+# =============================================================================
+# Dockerfile de PRODUCAO (multistage) - MeasureSoftGram Front (Next.js 12)
+# -----------------------------------------------------------------------------
+# Stages:
+#   base    -> imagem comum (Node 20 alpine + corepack/pnpm)
+#   deps    -> instala TODAS as dependencias (necessarias pro build)
+#   builder -> roda `pnpm build` (next build), com SERVICE_URL inlined
+#   runner  -> runtime enxuto que roda `next start` com deps de producao
+#
+# IMPORTANTE - SERVICE_URL e BUILD-TIME, NAO RUNTIME:
+#   next.config.js expoe SERVICE_URL via bloco `env:` e o codigo cliente
+#   (src/shared/services/api.ts) le `process.env.SERVICE_URL`. O Next.js
+#   INLINA esse valor no bundle do browser DURANTE O BUILD. Logo, a URL da API
+#   e fixada na imagem no momento do `pnpm build` e NAO pode ser trocada em
+#   runtime sem rebuildar. Por isso SERVICE_URL entra como build-arg (ARG/ENV
+#   no stage builder). Trocar a URL exige nova build da imagem.
+#   ignoreBuildErrors:true (next.config.js) e proposital: erros de TS antigos
+#   nao bloqueiam o build de producao - mantido como esta.
+# =============================================================================
 
-# Install dependencies needed for node-gyp and others if necessary
+# ---- base ----
+FROM node:20-alpine AS base
 RUN apk add --no-cache libc6-compat
+# package.json declara packageManager pnpm@9.0.0 -> corepack resolve a versao
+RUN corepack enable
+WORKDIR /app
 
-# Enable corepack for pnpm support
-RUN corepack enable pnpm
-
-WORKDIR /usr/src
-
-# Copy package management files
-COPY package.json pnpm-lock.yaml* ./
-
-# Install dependencies
+# ---- deps ----
+# Instala todas as dependencias (dev + prod) - necessarias pro `next build`.
+FROM base AS deps
+COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
-# Copy application code
+# ---- builder ----
+# Roda o build de producao. SERVICE_URL e demais envs publicos sao inlined aqui.
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# Expose port
+# build-args inlined no bundle (build-time). Default aponta pro /api atras do
+# proxy. Sobrescreva via --build-arg no CI conforme o ambiente.
+ARG SERVICE_URL=https://msgram.lappis.rocks/api
+ARG LOGIN_REDIRECT_URL
+ARG GITHUB_CLIENT_ID
+ENV SERVICE_URL=$SERVICE_URL
+ENV LOGIN_REDIRECT_URL=$LOGIN_REDIRECT_URL
+ENV GITHUB_CLIENT_ID=$GITHUB_CLIENT_ID
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN pnpm build
+
+# ---- prod-deps ----
+# node_modules apenas de producao, pra imagem final enxuta.
+FROM base AS prod-deps
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile --prod
+
+# ---- runner ----
+# Runtime: serve a app com `next start` (sem output:standalone; o projeto nao
+# usa SSR/getServerSideProps, mas next start cobre rotas dinamicas e assets).
+FROM base AS runner
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# usuario nao-root
+RUN addgroup -g 1001 -S nodejs && adduser -u 1001 -G nodejs -S nextjs
+
+COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=builder  /app/.next ./.next
+COPY --from=builder  /app/public ./public
+COPY --from=builder  /app/package.json ./package.json
+COPY --from=builder  /app/next.config.js ./next.config.js
+
+USER nextjs
+
 EXPOSE 3000
 
-# Start development server
-CMD ["pnpm", "dev"]
+# next start (package.json:9 -> "start": "next start")
+CMD ["pnpm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,21 @@
+# docker-compose de PRODUCAO local (build + smoke da imagem multistage).
+# A orquestracao de deploy real (proxy, rede, pull) vive em deploy/ no repo
+# Service; a .54 apenas faz PULL da imagem, nao builda.
+#
+# SERVICE_URL e BUILD-TIME (inlined no bundle pelo next.config.js). Passe via
+# build.args ou exporte no shell antes do `docker compose build`. Trocar a URL
+# exige rebuild da imagem.
 services:
   front:
     container_name: front
     build:
       context: .
+      args:
+        SERVICE_URL: ${SERVICE_URL:-https://msgram.lappis.rocks/api}
+        LOGIN_REDIRECT_URL: ${LOGIN_REDIRECT_URL:-}
+        GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
     restart: on-failure
     ports:
       - '3000:3000'
-    volumes:
-      - .:/usr/src/
-      - /usr/src/node_modules
-      - /usr/src/.next
-    env_file:
-      - .env
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     build:
       context: .
       args:
-        SERVICE_URL: ${SERVICE_URL:-https://msgram.lappis.rocks/api}
+        SERVICE_URL: ${SERVICE_URL:-http://localhost:8080/api/v1}
         LOGIN_REDIRECT_URL: ${LOGIN_REDIRECT_URL:-}
         GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
     restart: on-failure


### PR DESCRIPTION
## O que muda
Dockerfile de producao para o front (multistage: build + next start), no lugar do de desenvolvimento.

- Node 20, pnpm, next build seguido de next start
- Build-args inlined em build-time pelo next.config: SERVICE_URL, GITHUB_CLIENT_ID, LOGIN_REDIRECT_URL
- O default de build aponta para o ambiente de desenvolvimento; o valor de cada ambiente vem via build-arg no CI (workflow de publish)

## Secrets necessarios no repo
- DOCKERHUB_USERNAME, DOCKERHUB_TOKEN
- GH_OAUTH_CLIENT_ID (o GitHub reserva o prefixo GITHUB_, por isso o nome do secret difere do build-arg), LOGIN_REDIRECT_URL
