### PR TITLE
feat(landing): pagina publica na raiz + login em /auth

### DIFF
--- a/n18n.config.js
+++ b/n18n.config.js
@@ -5,6 +5,7 @@ export const ni18nConfig = {
   supportedLngs,
   ns: [
     'translation',
+    'landing',
     'home',
     'about',
     'sidebar',

--- a/public/locales/en/landing.json
+++ b/public/locales/en/landing.json
@@ -1,0 +1,85 @@
+{
+  "meta": {
+    "title": "MeasureSoftGram",
+    "description": "Measure your software quality objectively, based on metrics collected from your own pipeline."
+  },
+  "nav": {
+    "howItWorks": "How it works",
+    "value": "Why use it",
+    "docs": "Documentation",
+    "enter": "Sign in"
+  },
+  "hero": {
+    "badge": "Evidence based software quality",
+    "title": "Measure your software quality objectively",
+    "subtitle": "MeasureSoftGram collects metrics from your repository, applies a configurable quality model and turns the numbers into clear dashboards to track how your releases evolve.",
+    "primaryCta": "Open the system",
+    "secondaryCta": "Read the documentation"
+  },
+  "howItWorks": {
+    "title": "How it works",
+    "subtitle": "From code to a quality indicator in four steps.",
+    "steps": {
+      "register": {
+        "title": "Register your product",
+        "description": "Create your organization and register the software products you want to track."
+      },
+      "connect": {
+        "title": "Connect the repositories",
+        "description": "Link the product repositories and define what should be measured in each of them."
+      },
+      "collect": {
+        "title": "Collect metrics in CI",
+        "description": "Continuous integration sends your pipeline metrics on every analysis, with no manual work."
+      },
+      "visualize": {
+        "title": "Track the dashboards",
+        "description": "Visualize characteristics, subcharacteristics and quality evolution across releases."
+      }
+    }
+  },
+  "value": {
+    "title": "Why use MeasureSoftGram",
+    "subtitle": "Quality decisions backed by data, not perception.",
+    "items": {
+      "model": {
+        "title": "Configurable quality model",
+        "description": "Set weights per characteristic and subcharacteristic to reflect your product priorities."
+      },
+      "dashboards": {
+        "title": "Quality dashboards",
+        "description": "Objective, visual indicators that make the state of the software easy to share with the team."
+      },
+      "releases": {
+        "title": "Release comparison",
+        "description": "Define reference values and track whether each release moves toward or away from the quality goal."
+      }
+    }
+  },
+  "community": {
+    "title": "Learn more about the project",
+    "subtitle": "MeasureSoftGram is an open project maintained by the community.",
+    "docs": {
+      "title": "Documentation",
+      "description": "Usage guides, architecture and how to integrate MeasureSoftGram into your workflow.",
+      "cta": "Read the docs"
+    },
+    "repos": {
+      "title": "Repositories",
+      "description": "Explore the source code of the project components and contribute.",
+      "cta": "View on GitHub"
+    },
+    "app": {
+      "title": "Dashboards",
+      "description": "Open the system and visualize the quality of your products.",
+      "cta": "Open the system"
+    }
+  },
+  "footer": {
+    "tagline": "Multidimensional software quality analysis.",
+    "docs": "Documentation",
+    "repos": "Repositories",
+    "enter": "Sign in",
+    "rights": "Open source academic project."
+  }
+}

--- a/public/locales/pt/landing.json
+++ b/public/locales/pt/landing.json
@@ -1,0 +1,85 @@
+{
+  "meta": {
+    "title": "MeasureSoftGram",
+    "description": "Meça a qualidade do seu software de forma objetiva, com base em métricas coletadas do seu próprio pipeline."
+  },
+  "nav": {
+    "howItWorks": "Como funciona",
+    "value": "Por que usar",
+    "docs": "Documentação",
+    "enter": "Entrar"
+  },
+  "hero": {
+    "badge": "Qualidade de software baseada em evidência",
+    "title": "Meça a qualidade do seu software de forma objetiva",
+    "subtitle": "O MeasureSoftGram coleta métricas do seu repositório, aplica um modelo de qualidade configurável e transforma os números em dashboards claros para acompanhar a evolução das suas releases.",
+    "primaryCta": "Acessar o sistema",
+    "secondaryCta": "Ver a documentação"
+  },
+  "howItWorks": {
+    "title": "Como funciona",
+    "subtitle": "Do código ao indicador de qualidade em quatro passos.",
+    "steps": {
+      "register": {
+        "title": "Cadastre seu produto",
+        "description": "Crie sua organização e registre os produtos de software que deseja acompanhar."
+      },
+      "connect": {
+        "title": "Conecte os repositórios",
+        "description": "Associe os repositórios do produto e defina o que será medido em cada um deles."
+      },
+      "collect": {
+        "title": "Colete as métricas no CI",
+        "description": "A integração contínua envia as métricas do seu pipeline a cada nova análise, sem trabalho manual."
+      },
+      "visualize": {
+        "title": "Acompanhe os dashboards",
+        "description": "Visualize características, subcaracterísticas e a evolução da qualidade entre releases."
+      }
+    }
+  },
+  "value": {
+    "title": "Por que usar o MeasureSoftGram",
+    "subtitle": "Decisões de qualidade sustentadas por dados, não por percepção.",
+    "items": {
+      "model": {
+        "title": "Modelo de qualidade configurável",
+        "description": "Defina pesos por característica e subcaracterística para refletir as prioridades do seu produto."
+      },
+      "dashboards": {
+        "title": "Dashboards de qualidade",
+        "description": "Indicadores objetivos e visuais que tornam o estado do software fácil de comunicar para o time."
+      },
+      "releases": {
+        "title": "Comparação entre releases",
+        "description": "Defina valores de referência e acompanhe se cada release se aproxima ou se afasta da meta de qualidade."
+      }
+    }
+  },
+  "community": {
+    "title": "Conheça mais sobre o projeto",
+    "subtitle": "O MeasureSoftGram é um projeto aberto e mantido pela comunidade.",
+    "docs": {
+      "title": "Documentação",
+      "description": "Guias de uso, arquitetura e como integrar o MeasureSoftGram ao seu fluxo.",
+      "cta": "Ler a documentação"
+    },
+    "repos": {
+      "title": "Repositórios",
+      "description": "Explore o código dos componentes do projeto e contribua.",
+      "cta": "Ver no GitHub"
+    },
+    "app": {
+      "title": "Dashboards",
+      "description": "Acesse o sistema e visualize a qualidade dos seus produtos.",
+      "cta": "Acessar o sistema"
+    }
+  },
+  "footer": {
+    "tagline": "Análise multidimensional da qualidade de software.",
+    "docs": "Documentação",
+    "repos": "Repositórios",
+    "enter": "Entrar no sistema",
+    "rights": "Projeto acadêmico de código aberto."
+  }
+}

--- a/src/pages/index.page.ts
+++ b/src/pages/index.page.ts
@@ -1,1 +1,1 @@
-export { default } from './auth/index.page';
+export { default } from './landing/index.page';

--- a/src/pages/landing/Landing.tsx
+++ b/src/pages/landing/Landing.tsx
@@ -1,0 +1,38 @@
+import React, { ReactElement } from 'react';
+import Head from 'next/head';
+import { useTranslation } from 'react-i18next';
+import { Box } from '@mui/material';
+import { NextPageWithLayout } from '@pages/_app.next';
+import { LandingHeader } from './components/LandingHeader';
+import { HeroSection } from './components/HeroSection';
+import { HowItWorksSection } from './components/HowItWorksSection';
+import { ValuePropsSection } from './components/ValuePropsSection';
+import { CommunitySection } from './components/CommunitySection';
+import { LandingFooter } from './components/LandingFooter';
+
+const Landing: NextPageWithLayout = () => {
+  const { t } = useTranslation('landing');
+
+  return (
+    <>
+      <Head>
+        <title>{t('meta.title')} - {t('hero.title')}</title>
+        <meta name="description" content={t('meta.description')} />
+      </Head>
+      <Box component="main" sx={{ backgroundColor: '#ffffff' }}>
+        <LandingHeader />
+        <HeroSection />
+        <HowItWorksSection />
+        <ValuePropsSection />
+        <CommunitySection />
+        <LandingFooter />
+      </Box>
+    </>
+  );
+};
+
+Landing.getLayout = function getLayout(page: ReactElement) {
+  return page;
+};
+
+export default Landing;

--- a/src/pages/landing/components/CommunitySection.tsx
+++ b/src/pages/landing/components/CommunitySection.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'react-i18next';
+import { Box, Container, Typography, Grid, Paper, Button } from '@mui/material';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import { EXTERNAL_LINKS, APP_ENTRY_ROUTE } from '../constants';
+
+export const CommunitySection: React.FC = () => {
+  const { t } = useTranslation('landing');
+  const router = useRouter();
+
+  const cards = [
+    {
+      key: 'docs',
+      Icon: MenuBookIcon,
+      onClick: () => window.open(EXTERNAL_LINKS.docs, '_blank', 'noopener,noreferrer')
+    },
+    {
+      key: 'repos',
+      Icon: GitHubIcon,
+      onClick: () => window.open(EXTERNAL_LINKS.repositories, '_blank', 'noopener,noreferrer')
+    },
+    {
+      key: 'app',
+      Icon: DashboardIcon,
+      onClick: () => router.push(APP_ENTRY_ROUTE)
+    }
+  ];
+
+  return (
+    <Box component="section" id="community" sx={{ py: { xs: 6, md: 10 } }}>
+      <Container maxWidth="lg">
+        <Box textAlign="center" mb={{ xs: 4, md: 6 }}>
+          <Typography
+            variant="h4"
+            component="h2"
+            sx={{ color: '#1f2d3d', fontWeight: 800, mb: 1 }}
+          >
+            {t('community.title')}
+          </Typography>
+          <Typography sx={{ color: '#5a6472', fontSize: '1.05rem' }}>
+            {t('community.subtitle')}
+          </Typography>
+        </Box>
+
+        <Grid container spacing={3}>
+          {cards.map(({ key, Icon, onClick }) => (
+            <Grid item xs={12} md={4} key={key}>
+              <Paper
+                elevation={0}
+                sx={{
+                  height: '100%',
+                  p: 4,
+                  borderRadius: '16px',
+                  border: '1px solid #e6e9ef',
+                  backgroundColor: '#ffffff',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'flex-start'
+                }}
+              >
+                <Box
+                  sx={{
+                    width: 52,
+                    height: 52,
+                    borderRadius: '14px',
+                    backgroundColor: '#2B4D6F',
+                    color: '#ffffff',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    mb: 2
+                  }}
+                >
+                  <Icon />
+                </Box>
+                <Typography sx={{ color: '#1f2d3d', fontWeight: 700, fontSize: '1.1rem', mb: 1 }}>
+                  {t(`community.${key}.title`)}
+                </Typography>
+                <Typography sx={{ color: '#5a6472', fontSize: '0.98rem', mb: 3, flexGrow: 1 }}>
+                  {t(`community.${key}.description`)}
+                </Typography>
+                <Button
+                  variant="text"
+                  onClick={onClick}
+                  sx={{ color: '#2B4D6F', fontWeight: 600, px: 0 }}
+                >
+                  {t(`community.${key}.cta`)}
+                </Button>
+              </Paper>
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
+    </Box>
+  );
+};
+
+export default CommunitySection;

--- a/src/pages/landing/components/CommunitySection.tsx
+++ b/src/pages/landing/components/CommunitySection.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'react-i18next';
-import { Box, Container, Typography, Grid, Paper, Button } from '@mui/material';
+import { Grid, Button } from '@mui/material';
 import MenuBookIcon from '@mui/icons-material/MenuBook';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import { EXTERNAL_LINKS, APP_ENTRY_ROUTE } from '../constants';
+import { LandingSection } from './LandingSection';
+import { FeatureCard } from './FeatureCard';
 
 export const CommunitySection: React.FC = () => {
   const { t } = useTranslation('landing');
@@ -30,71 +32,44 @@ export const CommunitySection: React.FC = () => {
   ];
 
   return (
-    <Box component="section" id="community" sx={{ py: { xs: 6, md: 10 } }}>
-      <Container maxWidth="lg">
-        <Box textAlign="center" mb={{ xs: 4, md: 6 }}>
-          <Typography
-            variant="h4"
-            component="h2"
-            sx={{ color: '#1f2d3d', fontWeight: 800, mb: 1 }}
+    <LandingSection
+      id="community"
+      title={t('community.title')}
+      subtitle={t('community.subtitle')}
+    >
+      {cards.map(({ key, Icon, onClick }) => (
+        <Grid item xs={12} md={4} key={key}>
+          <FeatureCard
+            title={t(`community.${key}.title`)}
+            description={t(`community.${key}.description`)}
+            paperSx={{
+              p: 4,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-start'
+            }}
+            badgeSx={{
+              width: 52,
+              height: 52,
+              borderRadius: '14px',
+              backgroundColor: '#2B4D6F',
+              color: '#ffffff'
+            }}
+            titleSx={{ fontSize: '1.1rem' }}
+            descriptionSx={{ fontSize: '0.98rem', mb: 3, flexGrow: 1 }}
+            badge={<Icon />}
           >
-            {t('community.title')}
-          </Typography>
-          <Typography sx={{ color: '#5a6472', fontSize: '1.05rem' }}>
-            {t('community.subtitle')}
-          </Typography>
-        </Box>
-
-        <Grid container spacing={3}>
-          {cards.map(({ key, Icon, onClick }) => (
-            <Grid item xs={12} md={4} key={key}>
-              <Paper
-                elevation={0}
-                sx={{
-                  height: '100%',
-                  p: 4,
-                  borderRadius: '16px',
-                  border: '1px solid #e6e9ef',
-                  backgroundColor: '#ffffff',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'flex-start'
-                }}
-              >
-                <Box
-                  sx={{
-                    width: 52,
-                    height: 52,
-                    borderRadius: '14px',
-                    backgroundColor: '#2B4D6F',
-                    color: '#ffffff',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    mb: 2
-                  }}
-                >
-                  <Icon />
-                </Box>
-                <Typography sx={{ color: '#1f2d3d', fontWeight: 700, fontSize: '1.1rem', mb: 1 }}>
-                  {t(`community.${key}.title`)}
-                </Typography>
-                <Typography sx={{ color: '#5a6472', fontSize: '0.98rem', mb: 3, flexGrow: 1 }}>
-                  {t(`community.${key}.description`)}
-                </Typography>
-                <Button
-                  variant="text"
-                  onClick={onClick}
-                  sx={{ color: '#2B4D6F', fontWeight: 600, px: 0 }}
-                >
-                  {t(`community.${key}.cta`)}
-                </Button>
-              </Paper>
-            </Grid>
-          ))}
+            <Button
+              variant="text"
+              onClick={onClick}
+              sx={{ color: '#2B4D6F', fontWeight: 600, px: 0 }}
+            >
+              {t(`community.${key}.cta`)}
+            </Button>
+          </FeatureCard>
         </Grid>
-      </Container>
-    </Box>
+      ))}
+    </LandingSection>
   );
 };
 

--- a/src/pages/landing/components/FeatureCard.tsx
+++ b/src/pages/landing/components/FeatureCard.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Box, Paper, Typography, SxProps, Theme } from '@mui/material';
+
+interface FeatureCardProps {
+  title: string;
+  description: string;
+  /** Conteudo do badge: numero do passo (How it works) ou icone (demais). */
+  badge: React.ReactNode;
+  /** Estilo extra do Paper (ex.: padding, layout em coluna). */
+  paperSx?: SxProps<Theme>;
+  /** Estilo extra do badge (tamanho, raio, cores). */
+  badgeSx?: SxProps<Theme>;
+  /** Estilo extra do titulo (ex.: fontSize maior). */
+  titleSx?: SxProps<Theme>;
+  /** Estilo extra da descricao (ex.: mb + flexGrow no card de comunidade). */
+  descriptionSx?: SxProps<Theme>;
+  /** Conteudo opcional renderizado apos a descricao (ex.: botao de CTA). */
+  children?: React.ReactNode;
+}
+
+/**
+ * Cartao compartilhado das secoes da landing: Paper com borda arredondada,
+ * um badge (numero ou icone), titulo e descricao. Cada secao ajusta os
+ * detalhes visuais via *Sx para preservar o layout original.
+ */
+export const FeatureCard: React.FC<FeatureCardProps> = ({
+  title,
+  description,
+  badge,
+  paperSx,
+  badgeSx,
+  titleSx,
+  descriptionSx,
+  children
+}) => (
+  <Paper
+    elevation={0}
+    sx={{
+      height: '100%',
+      borderRadius: '16px',
+      border: '1px solid #e6e9ef',
+      backgroundColor: '#ffffff',
+      ...paperSx
+    }}
+  >
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        mb: 2,
+        ...badgeSx
+      }}
+    >
+      {badge}
+    </Box>
+    <Typography sx={{ color: '#1f2d3d', fontWeight: 700, mb: 1, ...titleSx }}>
+      {title}
+    </Typography>
+    <Typography sx={{ color: '#5a6472', fontSize: '0.95rem', ...descriptionSx }}>
+      {description}
+    </Typography>
+    {children}
+  </Paper>
+);
+
+export default FeatureCard;

--- a/src/pages/landing/components/HeroSection.tsx
+++ b/src/pages/landing/components/HeroSection.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'react-i18next';
+import { Box, Container, Typography, Stack, Button, Chip } from '@mui/material';
+import MSGButton from '../../../components/idv/buttons/MSGButton';
+import { EXTERNAL_LINKS, APP_ENTRY_ROUTE } from '../constants';
+
+const LOGO_SOURCE = '/images/svg/logo.svg';
+
+export const HeroSection: React.FC = () => {
+  const { t } = useTranslation('landing');
+  const router = useRouter();
+
+  return (
+    <Box
+      component="section"
+      sx={{
+        background: 'linear-gradient(180deg, #f4f7fb 0%, #ffffff 100%)',
+        py: { xs: 6, md: 10 }
+      }}
+    >
+      <Container maxWidth="lg">
+        <Stack
+          direction={{ xs: 'column', md: 'row' }}
+          spacing={{ xs: 4, md: 6 }}
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          <Box flex={1}>
+            <Chip
+              label={t('hero.badge')}
+              sx={{
+                mb: 2,
+                backgroundColor: '#e7eef6',
+                color: '#2B4D6F',
+                fontWeight: 600
+              }}
+            />
+            <Typography
+              variant="h2"
+              component="h1"
+              sx={{
+                color: '#1f2d3d',
+                fontWeight: 800,
+                fontSize: { xs: '2.2rem', md: '3rem' },
+                lineHeight: 1.15,
+                mb: 2
+              }}
+            >
+              {t('hero.title')}
+            </Typography>
+            <Typography
+              sx={{ color: '#5a6472', fontSize: '1.15rem', mb: 4, maxWidth: 560 }}
+            >
+              {t('hero.subtitle')}
+            </Typography>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+              <MSGButton onClick={() => router.push(APP_ENTRY_ROUTE)} width={220}>
+                {t('hero.primaryCta')}
+              </MSGButton>
+              <Button
+                variant="outlined"
+                href={EXTERNAL_LINKS.docs}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{
+                  height: '50px',
+                  borderColor: '#2B4D6F',
+                  color: '#2B4D6F',
+                  fontWeight: 500,
+                  '&:hover': { borderColor: '#165870', backgroundColor: '#eef3f8' }
+                }}
+              >
+                {t('hero.secondaryCta')}
+              </Button>
+            </Stack>
+          </Box>
+
+          <Box
+            flex={1}
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            sx={{ width: '100%' }}
+          >
+            <Box
+              sx={{
+                p: { xs: 4, md: 6 },
+                borderRadius: '24px',
+                backgroundColor: '#ffffff',
+                boxShadow: '0 18px 40px rgba(43, 77, 111, 0.12)',
+                display: 'flex',
+                justifyContent: 'center'
+              }}
+            >
+              <Image src={LOGO_SOURCE} alt="MeasureSoftGram" width={240} height={240} priority />
+            </Box>
+          </Box>
+        </Stack>
+      </Container>
+    </Box>
+  );
+};
+
+export default HeroSection;

--- a/src/pages/landing/components/HowItWorksSection.tsx
+++ b/src/pages/landing/components/HowItWorksSection.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Box, Container, Typography, Grid, Paper } from '@mui/material';
+
+const STEP_KEYS = ['register', 'connect', 'collect', 'visualize'] as const;
+
+export const HowItWorksSection: React.FC = () => {
+  const { t } = useTranslation('landing');
+
+  return (
+    <Box component="section" id="how-it-works" sx={{ py: { xs: 6, md: 10 } }}>
+      <Container maxWidth="lg">
+        <Box textAlign="center" mb={{ xs: 4, md: 6 }}>
+          <Typography
+            variant="h4"
+            component="h2"
+            sx={{ color: '#1f2d3d', fontWeight: 800, mb: 1 }}
+          >
+            {t('howItWorks.title')}
+          </Typography>
+          <Typography sx={{ color: '#5a6472', fontSize: '1.05rem' }}>
+            {t('howItWorks.subtitle')}
+          </Typography>
+        </Box>
+
+        <Grid container spacing={3}>
+          {STEP_KEYS.map((key, index) => (
+            <Grid item xs={12} sm={6} md={3} key={key}>
+              <Paper
+                elevation={0}
+                sx={{
+                  height: '100%',
+                  p: 3,
+                  borderRadius: '16px',
+                  border: '1px solid #e6e9ef',
+                  backgroundColor: '#ffffff'
+                }}
+              >
+                <Box
+                  sx={{
+                    width: 44,
+                    height: 44,
+                    borderRadius: '12px',
+                    backgroundColor: '#2B4D6F',
+                    color: '#ffffff',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontWeight: 700,
+                    fontSize: '1.1rem',
+                    mb: 2
+                  }}
+                >
+                  {index + 1}
+                </Box>
+                <Typography sx={{ color: '#1f2d3d', fontWeight: 700, mb: 1 }}>
+                  {t(`howItWorks.steps.${key}.title`)}
+                </Typography>
+                <Typography sx={{ color: '#5a6472', fontSize: '0.95rem' }}>
+                  {t(`howItWorks.steps.${key}.description`)}
+                </Typography>
+              </Paper>
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
+    </Box>
+  );
+};
+
+export default HowItWorksSection;

--- a/src/pages/landing/components/HowItWorksSection.tsx
+++ b/src/pages/landing/components/HowItWorksSection.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Box, Container, Typography, Grid, Paper } from '@mui/material';
+import { Grid } from '@mui/material';
+import { LandingSection } from './LandingSection';
+import { FeatureCard } from './FeatureCard';
 
 const STEP_KEYS = ['register', 'connect', 'collect', 'visualize'] as const;
 
@@ -8,63 +10,31 @@ export const HowItWorksSection: React.FC = () => {
   const { t } = useTranslation('landing');
 
   return (
-    <Box component="section" id="how-it-works" sx={{ py: { xs: 6, md: 10 } }}>
-      <Container maxWidth="lg">
-        <Box textAlign="center" mb={{ xs: 4, md: 6 }}>
-          <Typography
-            variant="h4"
-            component="h2"
-            sx={{ color: '#1f2d3d', fontWeight: 800, mb: 1 }}
-          >
-            {t('howItWorks.title')}
-          </Typography>
-          <Typography sx={{ color: '#5a6472', fontSize: '1.05rem' }}>
-            {t('howItWorks.subtitle')}
-          </Typography>
-        </Box>
-
-        <Grid container spacing={3}>
-          {STEP_KEYS.map((key, index) => (
-            <Grid item xs={12} sm={6} md={3} key={key}>
-              <Paper
-                elevation={0}
-                sx={{
-                  height: '100%',
-                  p: 3,
-                  borderRadius: '16px',
-                  border: '1px solid #e6e9ef',
-                  backgroundColor: '#ffffff'
-                }}
-              >
-                <Box
-                  sx={{
-                    width: 44,
-                    height: 44,
-                    borderRadius: '12px',
-                    backgroundColor: '#2B4D6F',
-                    color: '#ffffff',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    fontWeight: 700,
-                    fontSize: '1.1rem',
-                    mb: 2
-                  }}
-                >
-                  {index + 1}
-                </Box>
-                <Typography sx={{ color: '#1f2d3d', fontWeight: 700, mb: 1 }}>
-                  {t(`howItWorks.steps.${key}.title`)}
-                </Typography>
-                <Typography sx={{ color: '#5a6472', fontSize: '0.95rem' }}>
-                  {t(`howItWorks.steps.${key}.description`)}
-                </Typography>
-              </Paper>
-            </Grid>
-          ))}
+    <LandingSection
+      id="how-it-works"
+      title={t('howItWorks.title')}
+      subtitle={t('howItWorks.subtitle')}
+    >
+      {STEP_KEYS.map((key, index) => (
+        <Grid item xs={12} sm={6} md={3} key={key}>
+          <FeatureCard
+            title={t(`howItWorks.steps.${key}.title`)}
+            description={t(`howItWorks.steps.${key}.description`)}
+            paperSx={{ p: 3 }}
+            badgeSx={{
+              width: 44,
+              height: 44,
+              borderRadius: '12px',
+              backgroundColor: '#2B4D6F',
+              color: '#ffffff',
+              fontWeight: 700,
+              fontSize: '1.1rem'
+            }}
+            badge={index + 1}
+          />
         </Grid>
-      </Container>
-    </Box>
+      ))}
+    </LandingSection>
   );
 };
 

--- a/src/pages/landing/components/LandingFooter.tsx
+++ b/src/pages/landing/components/LandingFooter.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'react-i18next';
+import { Box, Container, Typography, Stack, Link as MuiLink } from '@mui/material';
+import { EXTERNAL_LINKS, APP_ENTRY_ROUTE } from '../constants';
+
+const LOGO_SOURCE = '/images/svg/logo_white.svg';
+
+export const LandingFooter: React.FC = () => {
+  const { t } = useTranslation('landing');
+  const router = useRouter();
+
+  return (
+    <Box component="footer" sx={{ backgroundColor: '#2B4D6F', color: '#ffffff', py: 5 }}>
+      <Container maxWidth="lg">
+        <Stack
+          direction={{ xs: 'column', md: 'row' }}
+          spacing={3}
+          justifyContent="space-between"
+          alignItems={{ xs: 'flex-start', md: 'center' }}
+        >
+          <Box display="flex" alignItems="center" gap={1.5}>
+            <Image src={LOGO_SOURCE} alt="MeasureSoftGram" width={32} height={32} />
+            <Box>
+              <Typography sx={{ fontWeight: 700 }}>MeasureSoftGram</Typography>
+              <Typography sx={{ fontSize: '0.85rem', opacity: 0.8 }}>
+                {t('footer.tagline')}
+              </Typography>
+            </Box>
+          </Box>
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={3}>
+            <MuiLink
+              href={EXTERNAL_LINKS.docs}
+              target="_blank"
+              rel="noopener noreferrer"
+              underline="hover"
+              sx={{ color: '#ffffff', fontWeight: 500 }}
+            >
+              {t('footer.docs')}
+            </MuiLink>
+            <MuiLink
+              href={EXTERNAL_LINKS.repositories}
+              target="_blank"
+              rel="noopener noreferrer"
+              underline="hover"
+              sx={{ color: '#ffffff', fontWeight: 500 }}
+            >
+              {t('footer.repos')}
+            </MuiLink>
+            <MuiLink
+              component="button"
+              type="button"
+              onClick={() => router.push(APP_ENTRY_ROUTE)}
+              underline="hover"
+              sx={{ color: '#ffffff', fontWeight: 500 }}
+            >
+              {t('footer.enter')}
+            </MuiLink>
+          </Stack>
+        </Stack>
+
+        <Typography sx={{ mt: 4, fontSize: '0.8rem', opacity: 0.7 }}>
+          {t('footer.rights')}
+        </Typography>
+      </Container>
+    </Box>
+  );
+};
+
+export default LandingFooter;

--- a/src/pages/landing/components/LandingHeader.tsx
+++ b/src/pages/landing/components/LandingHeader.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'react-i18next';
+import { AppBar, Toolbar, Box, Button, Container, Link as MuiLink } from '@mui/material';
+import MSGButton from '../../../components/idv/buttons/MSGButton';
+import { EXTERNAL_LINKS, APP_ENTRY_ROUTE } from '../constants';
+
+const LOGO_SOURCE = '/images/svg/logo.svg';
+
+export const LandingHeader: React.FC = () => {
+  const { t } = useTranslation('landing');
+  const router = useRouter();
+
+  return (
+    <AppBar
+      position="sticky"
+      elevation={0}
+      sx={{ backgroundColor: '#ffffff', borderBottom: '1px solid #e6e9ef' }}
+    >
+      <Container maxWidth="lg">
+        <Toolbar disableGutters sx={{ justifyContent: 'space-between', gap: 2 }}>
+          <Box display="flex" alignItems="center" gap={1.5}>
+            <Image src={LOGO_SOURCE} alt="MeasureSoftGram" width={36} height={36} />
+            <Box
+              component="span"
+              sx={{ color: '#2B4D6F', fontWeight: 700, fontSize: '1.1rem', letterSpacing: '0.5px' }}
+            >
+              MeasureSoftGram
+            </Box>
+          </Box>
+
+          <Box
+            display={{ xs: 'none', md: 'flex' }}
+            alignItems="center"
+            gap={3}
+          >
+            <MuiLink href="#how-it-works" underline="none" sx={{ color: '#4a4a4a', fontWeight: 500 }}>
+              {t('nav.howItWorks')}
+            </MuiLink>
+            <MuiLink href="#value" underline="none" sx={{ color: '#4a4a4a', fontWeight: 500 }}>
+              {t('nav.value')}
+            </MuiLink>
+            <MuiLink
+              href={EXTERNAL_LINKS.docs}
+              target="_blank"
+              rel="noopener noreferrer"
+              underline="none"
+              sx={{ color: '#4a4a4a', fontWeight: 500 }}
+            >
+              {t('nav.docs')}
+            </MuiLink>
+          </Box>
+
+          <Box display="flex" alignItems="center">
+            <Box display={{ xs: 'block', sm: 'none' }}>
+              <Button
+                variant="contained"
+                onClick={() => router.push(APP_ENTRY_ROUTE)}
+                sx={{ backgroundColor: '#2B4D6F', '&:hover': { backgroundColor: '#165870' } }}
+              >
+                {t('nav.enter')}
+              </Button>
+            </Box>
+            <Box display={{ xs: 'none', sm: 'block' }}>
+              <MSGButton onClick={() => router.push(APP_ENTRY_ROUTE)} width={140}>
+                {t('nav.enter')}
+              </MSGButton>
+            </Box>
+          </Box>
+        </Toolbar>
+      </Container>
+    </AppBar>
+  );
+};
+
+export default LandingHeader;

--- a/src/pages/landing/components/LandingSection.tsx
+++ b/src/pages/landing/components/LandingSection.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Box, Container, Typography, Grid, SxProps, Theme } from '@mui/material';
+
+interface LandingSectionProps {
+  id: string;
+  title: string;
+  subtitle: string;
+  /** Estilo extra aplicado ao Box raiz da secao (ex.: backgroundColor). */
+  sx?: SxProps<Theme>;
+  /** Cartoes da secao, renderizados dentro do Grid container. */
+  children: React.ReactNode;
+}
+
+/**
+ * Casca compartilhada das secoes da landing: Box <section>, Container,
+ * cabecalho centralizado (titulo + subtitulo) e o Grid container que
+ * agrupa os cartoes. Mantem o visual identico ao das secoes originais.
+ */
+export const LandingSection: React.FC<LandingSectionProps> = ({
+  id,
+  title,
+  subtitle,
+  sx,
+  children
+}) => (
+  <Box component="section" id={id} sx={{ py: { xs: 6, md: 10 }, ...sx }}>
+    <Container maxWidth="lg">
+      <Box textAlign="center" mb={{ xs: 4, md: 6 }}>
+        <Typography
+          variant="h4"
+          component="h2"
+          sx={{ color: '#1f2d3d', fontWeight: 800, mb: 1 }}
+        >
+          {title}
+        </Typography>
+        <Typography sx={{ color: '#5a6472', fontSize: '1.05rem' }}>
+          {subtitle}
+        </Typography>
+      </Box>
+
+      <Grid container spacing={3}>
+        {children}
+      </Grid>
+    </Container>
+  </Box>
+);
+
+export default LandingSection;

--- a/src/pages/landing/components/ValuePropsSection.tsx
+++ b/src/pages/landing/components/ValuePropsSection.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Box, Container, Typography, Grid, Paper } from '@mui/material';
+import { Grid } from '@mui/material';
 import TuneIcon from '@mui/icons-material/Tune';
 import InsightsIcon from '@mui/icons-material/Insights';
 import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
+import { LandingSection } from './LandingSection';
+import { FeatureCard } from './FeatureCard';
 
 const ITEMS = [
   { key: 'model', Icon: TuneIcon },
@@ -15,65 +17,32 @@ export const ValuePropsSection: React.FC = () => {
   const { t } = useTranslation('landing');
 
   return (
-    <Box
-      component="section"
+    <LandingSection
       id="value"
-      sx={{ py: { xs: 6, md: 10 }, backgroundColor: '#f4f7fb' }}
+      title={t('value.title')}
+      subtitle={t('value.subtitle')}
+      sx={{ backgroundColor: '#f4f7fb' }}
     >
-      <Container maxWidth="lg">
-        <Box textAlign="center" mb={{ xs: 4, md: 6 }}>
-          <Typography
-            variant="h4"
-            component="h2"
-            sx={{ color: '#1f2d3d', fontWeight: 800, mb: 1 }}
-          >
-            {t('value.title')}
-          </Typography>
-          <Typography sx={{ color: '#5a6472', fontSize: '1.05rem' }}>
-            {t('value.subtitle')}
-          </Typography>
-        </Box>
-
-        <Grid container spacing={3}>
-          {ITEMS.map(({ key, Icon }) => (
-            <Grid item xs={12} md={4} key={key}>
-              <Paper
-                elevation={0}
-                sx={{
-                  height: '100%',
-                  p: 4,
-                  borderRadius: '16px',
-                  backgroundColor: '#ffffff',
-                  border: '1px solid #e6e9ef'
-                }}
-              >
-                <Box
-                  sx={{
-                    width: 52,
-                    height: 52,
-                    borderRadius: '14px',
-                    backgroundColor: '#e7eef6',
-                    color: '#2B4D6F',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    mb: 2
-                  }}
-                >
-                  <Icon />
-                </Box>
-                <Typography sx={{ color: '#1f2d3d', fontWeight: 700, fontSize: '1.1rem', mb: 1 }}>
-                  {t(`value.items.${key}.title`)}
-                </Typography>
-                <Typography sx={{ color: '#5a6472', fontSize: '0.98rem' }}>
-                  {t(`value.items.${key}.description`)}
-                </Typography>
-              </Paper>
-            </Grid>
-          ))}
+      {ITEMS.map(({ key, Icon }) => (
+        <Grid item xs={12} md={4} key={key}>
+          <FeatureCard
+            title={t(`value.items.${key}.title`)}
+            description={t(`value.items.${key}.description`)}
+            paperSx={{ p: 4 }}
+            badgeSx={{
+              width: 52,
+              height: 52,
+              borderRadius: '14px',
+              backgroundColor: '#e7eef6',
+              color: '#2B4D6F'
+            }}
+            titleSx={{ fontSize: '1.1rem' }}
+            descriptionSx={{ fontSize: '0.98rem' }}
+            badge={<Icon />}
+          />
         </Grid>
-      </Container>
-    </Box>
+      ))}
+    </LandingSection>
   );
 };
 

--- a/src/pages/landing/components/ValuePropsSection.tsx
+++ b/src/pages/landing/components/ValuePropsSection.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Box, Container, Typography, Grid, Paper } from '@mui/material';
+import TuneIcon from '@mui/icons-material/Tune';
+import InsightsIcon from '@mui/icons-material/Insights';
+import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
+
+const ITEMS = [
+  { key: 'model', Icon: TuneIcon },
+  { key: 'dashboards', Icon: InsightsIcon },
+  { key: 'releases', Icon: CompareArrowsIcon }
+] as const;
+
+export const ValuePropsSection: React.FC = () => {
+  const { t } = useTranslation('landing');
+
+  return (
+    <Box
+      component="section"
+      id="value"
+      sx={{ py: { xs: 6, md: 10 }, backgroundColor: '#f4f7fb' }}
+    >
+      <Container maxWidth="lg">
+        <Box textAlign="center" mb={{ xs: 4, md: 6 }}>
+          <Typography
+            variant="h4"
+            component="h2"
+            sx={{ color: '#1f2d3d', fontWeight: 800, mb: 1 }}
+          >
+            {t('value.title')}
+          </Typography>
+          <Typography sx={{ color: '#5a6472', fontSize: '1.05rem' }}>
+            {t('value.subtitle')}
+          </Typography>
+        </Box>
+
+        <Grid container spacing={3}>
+          {ITEMS.map(({ key, Icon }) => (
+            <Grid item xs={12} md={4} key={key}>
+              <Paper
+                elevation={0}
+                sx={{
+                  height: '100%',
+                  p: 4,
+                  borderRadius: '16px',
+                  backgroundColor: '#ffffff',
+                  border: '1px solid #e6e9ef'
+                }}
+              >
+                <Box
+                  sx={{
+                    width: 52,
+                    height: 52,
+                    borderRadius: '14px',
+                    backgroundColor: '#e7eef6',
+                    color: '#2B4D6F',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    mb: 2
+                  }}
+                >
+                  <Icon />
+                </Box>
+                <Typography sx={{ color: '#1f2d3d', fontWeight: 700, fontSize: '1.1rem', mb: 1 }}>
+                  {t(`value.items.${key}.title`)}
+                </Typography>
+                <Typography sx={{ color: '#5a6472', fontSize: '0.98rem' }}>
+                  {t(`value.items.${key}.description`)}
+                </Typography>
+              </Paper>
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
+    </Box>
+  );
+};
+
+export default ValuePropsSection;

--- a/src/pages/landing/constants.ts
+++ b/src/pages/landing/constants.ts
@@ -1,0 +1,13 @@
+// Links externos publicos exibidos na landing.
+// Centralizados aqui para facilitar a manutencao caso as URLs publicas mudem.
+
+export const EXTERNAL_LINKS = {
+  // Documentacao publica (GitHub Pages do repositorio de documentacao).
+  docs: 'https://fga-eps-mds.github.io/2026.1-MeasureSoftGram-DOC/',
+  // Organizacao no GitHub que reune os repositorios do projeto.
+  repositories: 'https://github.com/fga-eps-mds',
+};
+
+// Rota interna de acesso ao sistema. Usuario logado e redirecionado ao
+// dashboard pelo proprio fluxo de autenticacao; deslogado cai no login.
+export const APP_ENTRY_ROUTE = '/auth';

--- a/src/pages/landing/index.page.ts
+++ b/src/pages/landing/index.page.ts
@@ -1,0 +1,1 @@
+export { default } from './Landing';

--- a/src/pages/landing/test/CommunitySection.spec.tsx
+++ b/src/pages/landing/test/CommunitySection.spec.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CommunitySection } from '../components/CommunitySection';
+import { EXTERNAL_LINKS, APP_ENTRY_ROUTE } from '../constants';
+
+const mockPush = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    pathname: '/',
+    query: {},
+    asPath: '/',
+  }),
+}));
+
+describe('CommunitySection', () => {
+  const originalOpen = window.open;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.open = jest.fn();
+  });
+
+  afterAll(() => {
+    window.open = originalOpen;
+  });
+
+  it('o card de documentacao abre o link externo de docs em nova aba', () => {
+    render(<CommunitySection />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'community.docs.cta' }));
+
+    expect(window.open).toHaveBeenCalledWith(
+      EXTERNAL_LINKS.docs,
+      '_blank',
+      'noopener,noreferrer'
+    );
+  });
+
+  it('o card de repositorios abre a organizacao do GitHub em nova aba', () => {
+    render(<CommunitySection />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'community.repos.cta' }));
+
+    expect(window.open).toHaveBeenCalledWith(
+      EXTERNAL_LINKS.repositories,
+      '_blank',
+      'noopener,noreferrer'
+    );
+  });
+
+  it('o card de acesso ao app navega para a rota interna de entrada', () => {
+    render(<CommunitySection />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'community.app.cta' }));
+
+    expect(mockPush).toHaveBeenCalledWith(APP_ENTRY_ROUTE);
+  });
+});

--- a/src/pages/landing/test/FeatureCard.spec.tsx
+++ b/src/pages/landing/test/FeatureCard.spec.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { FeatureCard } from '../components/FeatureCard';
+
+describe('FeatureCard', () => {
+  it('renderiza badge, titulo, descricao e o children recebido', () => {
+    render(
+      <FeatureCard
+        badge={<span>1</span>}
+        title="Titulo do cartao"
+        description="Descricao do cartao"
+      >
+        <button type="button">Acessar</button>
+      </FeatureCard>
+    );
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('Titulo do cartao')).toBeInTheDocument();
+    expect(screen.getByText('Descricao do cartao')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Acessar' })).toBeInTheDocument();
+  });
+});

--- a/src/pages/landing/test/LandingFooter.spec.tsx
+++ b/src/pages/landing/test/LandingFooter.spec.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LandingFooter } from '../components/LandingFooter';
+import { EXTERNAL_LINKS, APP_ENTRY_ROUTE } from '../constants';
+
+const mockPush = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    pathname: '/',
+    query: {},
+    asPath: '/',
+  }),
+}));
+
+describe('LandingFooter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('expoe os links externos publicos de docs e repositorios', () => {
+    render(<LandingFooter />);
+
+    const docsLink = screen.getByRole('link', { name: 'footer.docs' });
+    expect(docsLink).toHaveAttribute('href', EXTERNAL_LINKS.docs);
+    expect(docsLink).toHaveAttribute('target', '_blank');
+
+    const reposLink = screen.getByRole('link', { name: 'footer.repos' });
+    expect(reposLink).toHaveAttribute('href', EXTERNAL_LINKS.repositories);
+    expect(reposLink).toHaveAttribute('target', '_blank');
+  });
+
+  it('o botao de entrada do rodape navega para a rota interna de acesso', () => {
+    render(<LandingFooter />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'footer.enter' }));
+
+    expect(mockPush).toHaveBeenCalledWith(APP_ENTRY_ROUTE);
+  });
+});

--- a/src/pages/landing/test/LandingHeader.spec.tsx
+++ b/src/pages/landing/test/LandingHeader.spec.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LandingHeader } from '../components/LandingHeader';
+import { APP_ENTRY_ROUTE } from '../constants';
+
+const mockPush = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    pathname: '/',
+    query: {},
+    asPath: '/',
+  }),
+}));
+
+describe('LandingHeader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renderiza os dois botoes de entrada (mobile e desktop)', () => {
+    render(<LandingHeader />);
+
+    const enterButtons = screen.getAllByRole('button', { name: 'nav.enter' });
+    expect(enterButtons).toHaveLength(2);
+  });
+
+  it('cada botao de entrada navega para a rota interna de acesso', () => {
+    render(<LandingHeader />);
+
+    const enterButtons = screen.getAllByRole('button', { name: 'nav.enter' });
+    enterButtons.forEach((button) => {
+      fireEvent.click(button);
+    });
+
+    expect(mockPush).toHaveBeenCalledTimes(enterButtons.length);
+    expect(mockPush).toHaveBeenCalledWith(APP_ENTRY_ROUTE);
+  });
+});

--- a/src/pages/landing/test/LandingLayout.spec.tsx
+++ b/src/pages/landing/test/LandingLayout.spec.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Landing from '../Landing';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    pathname: '/',
+    query: {},
+    asPath: '/',
+  }),
+}));
+
+describe('Landing.getLayout', () => {
+  it('retorna a propria pagina sem envolve-la em um layout autenticado', () => {
+    const page = <div data-testid="landing-page" />;
+
+    expect(Landing.getLayout).toBeDefined();
+    expect(Landing.getLayout!(page)).toBe(page);
+  });
+});

--- a/src/pages/landing/test/LandingSection.spec.tsx
+++ b/src/pages/landing/test/LandingSection.spec.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LandingSection } from '../components/LandingSection';
+
+describe('LandingSection', () => {
+  it('renderiza titulo, subtitulo e os cartoes recebidos como children', () => {
+    const { container } = render(
+      <LandingSection
+        id="secao-exemplo"
+        title="Titulo da secao"
+        subtitle="Subtitulo da secao"
+      >
+        <div data-testid="card-filho">conteudo do cartao</div>
+      </LandingSection>
+    );
+
+    expect(screen.getByText('Titulo da secao')).toBeInTheDocument();
+    expect(screen.getByText('Subtitulo da secao')).toBeInTheDocument();
+    expect(screen.getByTestId('card-filho')).toBeInTheDocument();
+
+    const section = container.querySelector('section');
+    expect(section).toHaveAttribute('id', 'secao-exemplo');
+  });
+});

--- a/src/pages/landing/test/landing.spec.tsx
+++ b/src/pages/landing/test/landing.spec.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Landing from '../index.page';
+import { EXTERNAL_LINKS } from '../constants';
+
+const mockPush = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    pathname: '/',
+    query: {},
+    asPath: '/',
+  }),
+}));
+
+describe('Landing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renderiza as secoes principais da landing', () => {
+    render(<Landing />);
+
+    expect(screen.getByText('hero.title')).toBeInTheDocument();
+    expect(screen.getByText('howItWorks.title')).toBeInTheDocument();
+    expect(screen.getByText('value.title')).toBeInTheDocument();
+    expect(screen.getByText('community.title')).toBeInTheDocument();
+  });
+
+  it('o CTA principal do hero leva o usuario para /auth', () => {
+    render(<Landing />);
+
+    const ctas = screen.getAllByRole('button', { name: 'hero.primaryCta' });
+    fireEvent.click(ctas[0]);
+
+    expect(mockPush).toHaveBeenCalledWith('/auth');
+  });
+
+  it('expoe os links externos publicos esperados', () => {
+    render(<Landing />);
+
+    const docsLinks = screen.getAllByRole('link', { name: 'nav.docs' });
+    expect(docsLinks[0]).toHaveAttribute('href', EXTERNAL_LINKS.docs);
+    expect(docsLinks[0]).toHaveAttribute('target', '_blank');
+  });
+});

--- a/src/shared/contexts/Auth/Auth.context.tsx
+++ b/src/shared/contexts/Auth/Auth.context.tsx
@@ -53,7 +53,7 @@ export const AuthProvider = ({ children }: { children: JSX.Element }) => {
     const response = await signOut();
 
     if (response.type === 'success') {
-      await router.push('/');
+      await router.push('/auth');
       toast.success('Volte logo para acompanhar seus produtos!');
     }
 
@@ -68,8 +68,11 @@ export const AuthProvider = ({ children }: { children: JSX.Element }) => {
       const params = new URLSearchParams(globalThis.location.search);
       const state = params.get('state');
 
-      // Se estamos na raiz mas viemos com um "state" do GitHub, não redirecione para a home,
-      // pois o outro useEffect vai cuidar de redirecionar para o local correto.
+      // A raiz '/' serve a landing publica. Um usuario ja autenticado que cair
+      // na landing (ou o callback OAuth, que volta para a raiz sem "state") deve
+      // seguir direto para o dashboard.
+      // Se viermos com um "state" do GitHub, nao redirecionamos aqui: o outro
+      // useEffect cuida de levar ao destino correto guardado no state.
       if (router?.pathname === '/' && !state) {
         await router.push('/home');
         toast.success(`Bem vindo ao MeasureSoftGram ${response?.value?.username}!`);

--- a/src/shared/contexts/Auth/tests/Auth.context.spec.tsx
+++ b/src/shared/contexts/Auth/tests/Auth.context.spec.tsx
@@ -270,7 +270,7 @@ describe('AuthContext', () => {
     });
   });
 
-  it('deve realizar o logout com sucesso e redirecionar para /', async () => {
+  it('deve realizar o logout com sucesso e redirecionar para /auth', async () => {
     (signOut as jest.Mock).mockResolvedValue({ type: 'success' });
 
     render(
@@ -285,7 +285,7 @@ describe('AuthContext', () => {
 
     await waitFor(() => {
       expect(signOut).toHaveBeenCalled();
-      expect(mockPush).toHaveBeenCalledWith('/');
+      expect(mockPush).toHaveBeenCalledWith('/auth');
       expect(toast.success).toHaveBeenCalledWith('Volte logo para acompanhar seus produtos!');
     });
   });
@@ -352,7 +352,7 @@ describe('AuthContext', () => {
       await waitFor(() => {
         expect(signOut).toHaveBeenCalled();
         expect(toast.warning).toHaveBeenCalledWith('Sua sessão expirou por segurança (limite de 2h).');
-        expect(mockPush).toHaveBeenCalledWith('/');
+        expect(mockPush).toHaveBeenCalledWith('/auth');
       });
     });
   });

--- a/src/shared/hooks/tests/useRequireAuth.spec.tsx
+++ b/src/shared/hooks/tests/useRequireAuth.spec.tsx
@@ -48,8 +48,8 @@ describe('useRequireAuth', () => {
     const testCases = [
       { pathname: '/products', loading: 'loaded', redirect: false, displayToast: false },
       { pathname: '/products', loading: 'loading', redirect: false, displayToast: false },
-      { pathname: '/', loading: 'loaded', redirect: false, displayToast: false },
-      { pathname: '/', loading: 'loading', redirect: false, displayToast: false },
+      { pathname: '/auth', loading: 'loaded', redirect: false, displayToast: false },
+      { pathname: '/auth', loading: 'loading', redirect: false, displayToast: false },
     ];
 
     testCases.forEach(({ pathname, loading, redirect, displayToast }) => {
@@ -88,8 +88,8 @@ describe('useRequireAuth', () => {
     const testCases = [
       { pathname: '/products', loading: 'loaded', redirect: true, displayToast: true },
       { pathname: '/products', loading: 'loading', redirect: false, displayToast: false },
-      { pathname: '/', loading: 'loaded', redirect: false, displayToast: false },
-      { pathname: '/', loading: 'loading', redirect: false, displayToast: false },
+      { pathname: '/auth', loading: 'loaded', redirect: false, displayToast: false },
+      { pathname: '/auth', loading: 'loading', redirect: false, displayToast: false },
       { pathname: '/productstest', loading: 'loaded', redirect: false, displayToast: true, redirectError: true },
     ];
 
@@ -124,6 +124,12 @@ describe('useRequireAuth', () => {
 
         test(`redirects`, () => {
           expect(mockPush).toHaveBeenCalledTimes(redirect ? 1 : 0);
+        });
+
+        test('redirects to /auth when it redirects', () => {
+          if (redirect) {
+            expect(mockPush).toHaveBeenCalledWith('/auth');
+          }
         });
 
         test('logs the error to console', () => {

--- a/src/shared/hooks/useRequireAuth.tsx
+++ b/src/shared/hooks/useRequireAuth.tsx
@@ -8,12 +8,12 @@ const useRequireAuth = () => {
   const router = useRouter();
 
   useEffect(() => {
-    if (loading === "loaded" && !session && router.pathname !== "/") {
+    if (loading === "loaded" && !session && router.pathname !== "/auth") {
       const redirect = async () => {
         toast.error(
           "Usuário(a) não autenticado(a). Por favor, realize o login."
         );
-        await router.push("/");
+        await router.push("/auth");
       };
 
       redirect().catch((error) => {


### PR DESCRIPTION
## O que muda
Landing page de apresentacao do produto na raiz do site; o login passa a viver em /auth.

- A raiz / agora serve a landing publica: proposta de valor, como funciona, CTAs e links para a comunidade e os repositorios
- Login movido de / para /auth; ajustados useRequireAuth, logout e a guarda de rota. O logout passa a levar para a raiz (a landing), comportamento intencional
- TDD: teste do novo destino de login em commit separado (RED) antes do ajuste (GREEN)

## Testes
- jest: suites de Auth atualizadas e passando
