### PR TITLE
fix(landing): apontar link de documentacao para o repo central

### DIFF
--- a/src/pages/landing/constants.ts
+++ b/src/pages/landing/constants.ts
@@ -2,8 +2,9 @@
 // Centralizados aqui para facilitar a manutencao caso as URLs publicas mudem.
 
 export const EXTERNAL_LINKS = {
-  // Documentacao publica (GitHub Pages do repositorio de documentacao).
-  docs: 'https://fga-eps-mds.github.io/2026.1-MeasureSoftGram-DOC/',
+  // Documentacao publica (GitHub Pages do repositorio central de documentacao
+  // do projeto, MeasureSoftGram-Docs, onde vivem as paginas de comunidade).
+  docs: 'https://fga-eps-mds.github.io/MeasureSoftGram-Docs/',
   // Organizacao no GitHub que reune os repositorios do projeto.
   repositories: 'https://github.com/fga-eps-mds',
 };


### PR DESCRIPTION
## O que

A landing apontava o link de documentacao para o GitHub Pages do `2026.1-MeasureSoftGram-DOC` (repo de metricas do semestre), divergindo do combinado. Troquei para o repo central `MeasureSoftGram-Docs`, onde ficam as paginas de comunidade do projeto.

## Por que

O destino certo da documentacao publica e o repo central de docs, nao o repo de metricas do semestre. O link estava errado desde o primeiro commit da landing.

## Detalhe

O clone do `2026.1-MeasureSoftGram-DOC` no `metrics.yml` segue intacto: ali o repo e usado pra armazenar metricas, nao como documentacao publica.

Mudanca de uma linha em `src/pages/landing/constants.ts`. Os componentes leem `EXTERNAL_LINKS.docs` por referencia, entao mudam junto. Testes da landing verdes (17/17).