### PR TITLE
fix(front): versiona rotas da API com /v1 explicito

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-SERVICE_URL=http://localhost:8080/api/v1
-NEXT_PUBLIC_API_URL=http://localhost:8080/api/v1
+SERVICE_URL=http://localhost:8080/api
+NEXT_PUBLIC_API_URL=http://localhost:8080/api
 LOGIN_REDIRECT_URL=http://127.0.0.1:3000
 GITHUB_CLIENT_ID=

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ COPY . .
 
 # build-args inlined no bundle (build-time). O default e o ambiente de
 # desenvolvimento; o valor de cada ambiente vem via --build-arg no CI.
-ARG SERVICE_URL=http://localhost:8080/api/v1
+ARG SERVICE_URL=http://localhost:8080/api
 ARG LOGIN_REDIRECT_URL
 ARG GITHUB_CLIENT_ID
 ENV SERVICE_URL=$SERVICE_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     build:
       context: .
       args:
-        SERVICE_URL: ${SERVICE_URL:-http://localhost:8080/api/v1}
+        SERVICE_URL: ${SERVICE_URL:-http://localhost:8080/api}
         LOGIN_REDIRECT_URL: ${LOGIN_REDIRECT_URL:-}
         GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
     restart: on-failure

--- a/src/shared/services/Auth/Auth.service.tsx
+++ b/src/shared/services/Auth/Auth.service.tsx
@@ -3,7 +3,7 @@ import { AxiosError } from 'axios';
 
 export const signInCredentials = async (data: LoginFormData): Promise<Result<User>> => {
   try {
-    const response = await api.post('/accounts/login/', data);
+    const response = await api.post('/v1/accounts/login/', data);
 
     return { type: 'success', value: response?.data };
   } catch (err) {
@@ -14,7 +14,7 @@ export const signInCredentials = async (data: LoginFormData): Promise<Result<Use
 
 export const signInGithub = async (code: string): Promise<Result<{ key: string }>> => {
   try {
-    const response = await api.post('accounts/github/login/', { code });
+    const response = await api.post('/v1/accounts/github/login/', { code });
 
     return { type: 'success', value: response?.data };
   } catch (err) {
@@ -25,7 +25,7 @@ export const signInGithub = async (code: string): Promise<Result<{ key: string }
 
 export const signUp = async (data: SignUpFormData): Promise<Result<void>> => {
   try {
-    const response = await api.post('accounts/signin/', data);
+    const response = await api.post('/v1/accounts/signin/', data);
 
     return { type: 'success', value: response?.data };
   } catch (err) {
@@ -36,7 +36,7 @@ export const signUp = async (data: SignUpFormData): Promise<Result<void>> => {
 
 export const signOut = async (): Promise<Result<void>> => {
   try {
-    const response = await api.delete('accounts/logout/');
+    const response = await api.delete('/v1/accounts/logout/');
 
     return { type: 'success', value: response?.data };
   } catch (err) {
@@ -47,7 +47,7 @@ export const signOut = async (): Promise<Result<void>> => {
 
 export const getUserInfo = async (): Promise<Result<User>> => {
   try {
-    const response = await api.get('/accounts/');
+    const response = await api.get('/v1/accounts/');
 
     return { type: 'success', value: response?.data };
   } catch (err) {
@@ -58,7 +58,7 @@ export const getUserInfo = async (): Promise<Result<User>> => {
 
 export const getAccessToken = async (): Promise<Result<User>> => {
   try {
-    const response = await api.get('/accounts/access-token');
+    const response = await api.get('/v1/accounts/access-token');
 
     return { type: 'success', value: response?.data };
   } catch (err) {

--- a/src/shared/services/Auth/tests/Auth.service.spec.tsx
+++ b/src/shared/services/Auth/tests/Auth.service.spec.tsx
@@ -213,5 +213,81 @@ describe('Auth Service', () => {
 
   // ... Fim dos testes
 
+  // Testes de versionamento de rotas (/v1)
+  describe('versiona rotas com /v1', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('signInCredentials calls api.post with /v1/accounts/login/', async () => {
+      const data = { email: 'user@user.com', password: 'pass' };
+      (api.post as jest.Mock).mockImplementation(() =>
+        Promise.resolve({ data: {} } as AxiosResponse)
+      );
+
+      await signInCredentials(data);
+
+      expect(api.post).toHaveBeenCalledWith('/v1/accounts/login/', data);
+    });
+
+    it('signInGithub calls api.post with /v1/accounts/github/login/', async () => {
+      const code = 'githubCode';
+      (api.post as jest.Mock).mockImplementation(() =>
+        Promise.resolve({ data: {} } as AxiosResponse)
+      );
+
+      await signInGithub(code);
+
+      expect(api.post).toHaveBeenCalledWith('/v1/accounts/github/login/', { code });
+    });
+
+    it('signUp calls api.post with /v1/accounts/signin/', async () => {
+      const data = {
+        username: 'teste123',
+        first_name: 'teste',
+        last_name: 'teste',
+        email: 'teste@user.com',
+        password: 'userteste',
+        confirmPassword: '12345'
+      };
+      (api.post as jest.Mock).mockImplementation(() =>
+        Promise.resolve({ data: {} } as AxiosResponse)
+      );
+
+      await signUp(data);
+
+      expect(api.post).toHaveBeenCalledWith('/v1/accounts/signin/', data);
+    });
+
+    it('signOut calls api.delete with /v1/accounts/logout/', async () => {
+      (api.delete as jest.Mock).mockImplementation(() =>
+        Promise.resolve({ data: {} } as AxiosResponse)
+      );
+
+      await signOut();
+
+      expect(api.delete).toHaveBeenCalledWith('/v1/accounts/logout/');
+    });
+
+    it('getUserInfo calls api.get with /v1/accounts/', async () => {
+      (api.get as jest.Mock).mockImplementation(() =>
+        Promise.resolve({ data: {} } as AxiosResponse)
+      );
+
+      await getUserInfo();
+
+      expect(api.get).toHaveBeenCalledWith('/v1/accounts/');
+    });
+
+    it('getAccessToken calls api.get with /v1/accounts/access-token', async () => {
+      (api.get as jest.Mock).mockImplementation(() =>
+        Promise.resolve({ data: {} } as AxiosResponse)
+      );
+
+      await getAccessToken();
+
+      expect(api.get).toHaveBeenCalledWith('/v1/accounts/access-token');
+    });
+  });
 
 });

--- a/src/shared/services/balanceMatrix.ts
+++ b/src/shared/services/balanceMatrix.ts
@@ -3,7 +3,7 @@ import api from './api';
 
 class BalanceMatrixService {
   getBalanceMatrix() {
-    return api.get(`balance-matrix`);
+    return api.get(`/v1/balance-matrix`);
   }
 }
 

--- a/src/shared/services/organization.ts
+++ b/src/shared/services/organization.ts
@@ -38,7 +38,7 @@ class OrganizationQuery {
         throw new Error('Token de acesso não encontrado.');
       }
 
-      const response = await api.get('/organizations/', { headers });
+      const response = await api.get('/v1/organizations/', { headers });
       return { type: 'success', value: response.data.results as OrganizationFormData[] };
     } catch (error) {
       return { type: 'error', error: error as AxiosError };
@@ -51,7 +51,7 @@ class OrganizationQuery {
       if (!headers) {
         throw new Error('Token de acesso não encontrado.');
       }
-      const response = await api.post('/organizations/', data, { headers });
+      const response = await api.post('/v1/organizations/', data, { headers });
       return { type: 'success', value: response?.data };
     } catch (err) {
       const error = err as AxiosError;
@@ -76,7 +76,7 @@ class OrganizationQuery {
       if (!headers) {
         throw new Error('Token de acesso não encontrado.');
       }
-      const response = await api.get(`/organizations/${id}/`, { headers });
+      const response = await api.get(`/v1/organizations/${id}/`, { headers });
       return { type: 'success', value: response?.data };
     } catch (err) {
       const error = err as AxiosError;
@@ -90,7 +90,7 @@ class OrganizationQuery {
       if (!headers) {
         throw new Error('Token de acesso não encontrado.');
       }
-      const response = await api.put(`/organizations/${id}/`, data, { headers });
+      const response = await api.put(`/v1/organizations/${id}/`, data, { headers });
       return { type: 'success', value: response?.data };
     } catch (err) {
       const error = err as AxiosError;
@@ -115,7 +115,7 @@ class OrganizationQuery {
       if (!headers) {
         throw new Error('Token de acesso não encontrado.');
       }
-      const response = await api.delete(`/organizations/${id}/`, { headers });
+      const response = await api.delete(`/v1/organizations/${id}/`, { headers });
       return { type: 'success', value: response?.data };
     } catch (err) {
       const error = err as AxiosError;

--- a/src/shared/services/product.ts
+++ b/src/shared/services/product.ts
@@ -25,12 +25,12 @@ export interface ProductFormData {
 
 class ProductQuery {
   async getAllProducts(organizationId: string) {
-    return api.get(`/organizations/${organizationId}/products/`);
+    return api.get(`/v1/organizations/${organizationId}/products/`);
   }
 
   async getProductById(organizationId: string, productId: string): Promise<Result<ProductFormData>> {
     try {
-      const response = await api.get(`/organizations/${organizationId}/products/${productId}/`);
+      const response = await api.get(`/v1/organizations/${organizationId}/products/${productId}/`);
       return { type: 'success', value: response?.data };
     } catch (err) {
       const error = err as AxiosError;
@@ -40,7 +40,7 @@ class ProductQuery {
 
   async updateProduct(productId: string, data: ProductFormData): Promise<Result<Product>> {
     try {
-      const response = await api.put(`/organizations/${data.organizationId}/products/${productId}/`, data);
+      const response = await api.put(`/v1/organizations/${data.organizationId}/products/${productId}/`, data);
       return { type: 'success', value: response?.data };
     } catch (err) {
       const error = err as AxiosError;
@@ -57,100 +57,100 @@ class ProductQuery {
   }
 
   async getAllRepositories(organizationId: string, productId: string) {
-    return api.get(`/organizations/${organizationId}/products/${productId}/repositories`);
+    return api.get(`/v1/organizations/${organizationId}/products/${productId}/repositories`);
   }
 
   async getProductMeasuresHistory(organizationId: string, productId: string) {
-    const url = `organizations/${organizationId}/repository/${productId}/history/measures/`;
+    const url = `/v1/organizations/${organizationId}/repository/${productId}/history/measures/`;
     return api.get<MeasuresHistory>(url);
   }
 
   async postPreConfig(organizationId: string, productId: string, data: { name: string; data: PreConfigData }) {
-    return api.post(`/organizations/${organizationId}/products/${productId}/create/release-config/`, data);
+    return api.post(`/v1/organizations/${organizationId}/products/${productId}/create/release-config/`, data);
   }
 
   async getProductCurrentPreConfig(organizationId: string, productId: string) {
-    const url = `organizations/${organizationId}/products/${productId}/current/release-config/`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/current/release-config/`;
     return api.get<PreConfigRoot>(url);
   }
 
   async getProductDefaultPreConfig(organizationId: string, productId: string) {
-    const url = `organizations/${organizationId}/products/${productId}/default/pre-config/`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/default/pre-config/`;
     return api.get<PreConfigData>(url);
   }
 
   async getPreConfigEntitiesRelationship(organizationId: string, projectId: string) {
-    const url = `organizations/${organizationId}/products/${projectId}/entity-relationship-tree/`;
+    const url = `/v1/organizations/${organizationId}/products/${projectId}/entity-relationship-tree/`;
     return api.get<Array<PreConfigEntitiesRelationship>>(url);
   }
 
   async updateReleaseEndDate(organizationId: string, projectId: string, releaseId: string, data: any) {
-    const url = `organizations/${organizationId}/products/${projectId}/release/${releaseId}/update-end-at/`;
+    const url = `/v1/organizations/${organizationId}/products/${projectId}/release/${releaseId}/update-end-at/`;
     return api.put<Array<PreConfigEntitiesRelationship>>(url, data);
   }
 
   async getCharacteristicsLatestValues(organizationId: string, productId: string, repositoryId: string) {
-    const url = `organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/characteristics/`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/characteristics/`;
     return api.get<Array<LatestValues>>(url);
   }
 
   async getSubcharacteristicsLatestValues(organizationId: string, productId: string, repositoryId: string) {
-    const url = `organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/subcharacteristics/`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/subcharacteristics/`;
     return api.get<Array<LatestValues>>(url);
   }
 
   async getMeasuresLatestValues(organizationId: string, productId: string, repositoryId: string) {
-    const url = `organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/measures/`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/measures/`;
     return api.get<Array<LatestValues>>(url);
   }
 
   async getMetricsLatestValues(organizationId: string, productId: string, repositoryId: string) {
-    const url = `organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/metrics/`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/metrics/`;
     return api.get<Array<EntitiesMetrics>>(url);
   }
 
   async createProductGoal(organizationId: string, productId: string, data: ReleaseGoal) {
-    const url = `organizations/${organizationId}/products/${productId}/create/goal/`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/create/goal/`;
     return api.post(url, data);
   }
 
   async createProductRelease(organizationId: string, productId: string, data: any) {
-    const url = `organizations/${organizationId}/products/${productId}/release/`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/release/`;
     return api.post(url, data);
   }
 
   async getCompareGoalAccomplished(organizationId: string, productId: string, releaseId?: number) {
-    const url = `organizations/${organizationId}/products/${productId}/all/goal/`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/all/goal/`;
     return api.get(url, { params: releaseId && { release_id: releaseId } });
   }
 
   async getCurrentReleaseGoal(organizationId: string, productId: string) {
-    const url = `organizations/${organizationId}/products/${productId}/current/goal/`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/current/goal/`;
     return api.get(url);
   }
 
   async getProductRepositoriesTsqmiHistory(organizationId: string, productId: string) {
-    const url = `organizations/${organizationId}/products/${productId}/repositories-tsqmi-historical-values/`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/repositories-tsqmi-historical-values/`;
     return api.get<RepositoriesTsqmiHistory>(url);
   }
 
   async getProductRepositoriesLatestTsqmi(organizationId: string, productId: string) {
-    const url = `organizations/${organizationId}/products/${productId}/repositories-tsqmi-latest-values/`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/repositories-tsqmi-latest-values/`;
     return api.get<RepositoriesLatestTsqmi>(url);
   }
 
   async getCurrentGoal(organizationId: string, productId: string, releaseId?: number) {
-    const url = `organizations/${organizationId}/products/${productId}/current/goal/`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/current/goal/`;
     return api.get<any>(url, { params: releaseId && { release_id: releaseId } });
   }
 
   async getReleaseAnalysisDataByReleaseId(organizationId: string, productId: string, releaseId: string) {
-    const url = `organizations/${organizationId}/products/${productId}/release/${releaseId}/analysis_data`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/release/${releaseId}/analysis_data`;
     return api.get<any>(url);
   }
 
   getReleaseList(organizationId: string, productId: string, releaseId?: number): AxiosRequestConfig {
-    const url = `organizations/${organizationId}/products/${productId}/release/`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/release/`;
     return {
       url,
       method: 'get'
@@ -160,7 +160,7 @@ class ProductQuery {
 
   async createProduct(data: ProductFormData): Promise<Result<ProductFormData>> {
     try {
-      const response = await api.post(`/organizations/${data.organizationId}/products/`, data);
+      const response = await api.post(`/v1/organizations/${data.organizationId}/products/`, data);
       return { type: 'success', value: response?.data };
     } catch (err) {
       const error = err as AxiosError;
@@ -178,7 +178,7 @@ class ProductQuery {
 
   async deleteProduct(productId: string, organizationId: string | undefined): Promise<Result<void>> {
     try {
-      const response = await api.delete(`/organizations/${organizationId}/products/${productId}/`);
+      const response = await api.delete(`/v1/organizations/${organizationId}/products/${productId}/`);
       return { type: 'success', value: response?.data };
     } catch (err) {
       const error = err as AxiosError;
@@ -187,7 +187,7 @@ class ProductQuery {
   }
 
   async getIsReleaseValid(organizationId: string, productId: string, form: ReleaseInfoForm) {
-    const url = `organizations/${organizationId}/products/${productId}/release/is-valid/?nome=${form.release_name}&dt-inicial=${form.start_at}&dt-final=${form.end_at}`;
+    const url = `/v1/organizations/${organizationId}/products/${productId}/release/is-valid/?nome=${form.release_name}&dt-inicial=${form.start_at}&dt-final=${form.end_at}`;
     return api.get<any>(url);
   }
 }

--- a/src/shared/services/repository.ts
+++ b/src/shared/services/repository.ts
@@ -47,7 +47,7 @@ class Repository {
       }
 
       const response = await api.post(
-        `/organizations/${organizationId}/products/${productId}/repositories/`,
+        `/v1/organizations/${organizationId}/products/${productId}/repositories/`,
         { ...data, imported },
         {
           headers
@@ -75,7 +75,7 @@ class Repository {
       }
 
       const response = await api.put(
-        `/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/`,
+        `/v1/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/`,
         { ...data, imported },
         { headers }
       );
@@ -95,7 +95,7 @@ class Repository {
         throw new Error('Access token not found.');
       }
       const response = await api.delete(
-        `/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/`,
+        `/v1/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/`,
         { headers }
       );
       return { type: 'success', value: response?.data };
@@ -112,7 +112,7 @@ class Repository {
         throw new Error('Access token not found.');
       }
       const response = await api.get(
-        `/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/historical-values/${entity}/`,
+        `/v1/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/historical-values/${entity}/`,
         { headers }
       );
       return { type: 'success', value: response?.data };
@@ -122,13 +122,13 @@ class Repository {
   }
 
   getRepository(organizationId: string, productId: string, repositoryId: string): Promise<Result<any>> {
-    return api.get(`organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/`);
+    return api.get(`/v1/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/`);
   }
 
   getHistorical(props: HistoricalCharacteristicsProps): Promise<Result<any>> {
     const { organizationId, entity, productId, repositoryId } = props;
     return api.get(
-      `organizations/${organizationId}` +
+      `/v1/organizations/${organizationId}` +
         `/products/${productId}/repositories/${repositoryId}` +
         `/historical-values/${entity}/`
     );
@@ -139,7 +139,7 @@ class Repository {
 
     try {
       return await api.get(
-        `organizations/${organizationId}` +
+        `/v1/organizations/${organizationId}` +
           `/products/${productId}/repositories/${repositoryId}` +
           `/latest-values/${entity}/`
       );
@@ -151,7 +151,7 @@ class Repository {
   getTsqmiBadgeUrl(props: HistoricalCharacteristicsProps) {
     const { organizationId, entity, productId, repositoryId } = props;
     return (
-      `${api.getUri()}/organizations/${organizationId}` +
+      `${api.getUri()}/v1/organizations/${organizationId}` +
       `/products/${productId}/repositories/${repositoryId}` +
       `/latest-values/${entity}/badge`
     );

--- a/src/shared/services/subCharacteristics.ts
+++ b/src/shared/services/subCharacteristics.ts
@@ -10,13 +10,13 @@ interface HistoricalCharacteristicsProps {
 
 class SubCharacteristics {
   getRepository(organizationId: string, productId: string, repositoryId: string) {
-    return api.get(`organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/`);
+    return api.get(`/v1/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/`);
   }
 
   getHistoricalCharacteristics(props: HistoricalCharacteristicsProps) {
     const { organizationId, entity, productId, repositoryId } = props;
     return api.get(
-      `organizations/${organizationId}` +
+      `/v1/organizations/${organizationId}` +
         `/products/${productId}/repositories/${repositoryId}` +
         `/historical-values/${entity}/`
     );

--- a/src/shared/services/tests/balanceMatrix.spec.ts
+++ b/src/shared/services/tests/balanceMatrix.spec.ts
@@ -6,6 +6,6 @@ jest.mock('../api');
 describe('BalanceMatrix', () => {
   it('should call api.get with the right URL', async () => {
     await balanceMatrixService.getBalanceMatrix();
-    expect(api.get).toHaveBeenCalledWith('balance-matrix');
+    expect(api.get).toHaveBeenCalledWith('/v1/balance-matrix');
   });
 });

--- a/src/shared/services/tests/index.spec.ts
+++ b/src/shared/services/tests/index.spec.ts
@@ -7,13 +7,13 @@ describe('Auth Services', () => {
   it('should signInCredentials with the right URL and data', async () => {
     const data = { email: 'test@test.com', password: 'test' };
     await services.signInCredentials(data);
-    expect(api.post).toHaveBeenCalledWith('/accounts/login/', data);
+    expect(api.post).toHaveBeenCalledWith('/v1/accounts/login/', data);
   });
 
   it('should signInGithub with the right URL and data', async () => {
     const code = 'test_code';
     await services.signInGithub(code);
-    expect(api.post).toHaveBeenCalledWith('accounts/github/login/', { code });
+    expect(api.post).toHaveBeenCalledWith('/v1/accounts/github/login/', { code });
   });
 
   it('should signUp with the right URL and data', async () => {
@@ -28,22 +28,22 @@ describe('Auth Services', () => {
 
     await services.signUp(data);
 
-    expect(api.post).toHaveBeenCalledWith('accounts/signin/', data);
+    expect(api.post).toHaveBeenCalledWith('/v1/accounts/signin/', data);
   });
 
   it('should signOut with the right URL', async () => {
     await services.signOut();
-    expect(api.delete).toHaveBeenCalledWith('accounts/logout/');
+    expect(api.delete).toHaveBeenCalledWith('/v1/accounts/logout/');
   });
 
   it('should getUserInfo with the right URL', async () => {
     await services.getUserInfo();
-    expect(api.get).toHaveBeenCalledWith('/accounts/');
+    expect(api.get).toHaveBeenCalledWith('/v1/accounts/');
   });
 
   it('should getAccessToken with the right URL', async () => {
     await services.getAccessToken();
-    expect(api.get).toHaveBeenCalledWith('/accounts/access-token');
+    expect(api.get).toHaveBeenCalledWith('/v1/accounts/access-token');
   });
 
   afterEach(() => {

--- a/src/shared/services/tests/organization.spec.ts
+++ b/src/shared/services/tests/organization.spec.ts
@@ -33,7 +33,7 @@ describe('Organization Service', () => {
 
     const result = await organizationQuery.getAllOrganization();
 
-    expect(api.get).toHaveBeenCalled();
+    expect(api.get).toHaveBeenCalledWith('/v1/organizations/', expect.any(Object));
     expect(result.type).toEqual('success');
     if (result.type === 'success') {
       expect(result.value).toEqual(mockOrgs.results);
@@ -46,7 +46,7 @@ describe('Organization Service', () => {
 
     const result = await organizationQuery.getOrganizationById('1');
 
-    expect(api.get).toHaveBeenCalledWith('/organizations/1/', expect.any(Object));
+    expect(api.get).toHaveBeenCalledWith('/v1/organizations/1/', expect.any(Object));
     expect(result.type).toEqual('success');
   });
 
@@ -54,7 +54,7 @@ describe('Organization Service', () => {
     (api.post as jest.Mock).mockResolvedValue({ data: { id: '2', ...mockPayload } });
 
     const result = await organizationQuery.createOrganization(mockPayload);
-    expect(api.post).toHaveBeenCalled();
+    expect(api.post).toHaveBeenCalledWith('/v1/organizations/', mockPayload, expect.any(Object));
     expect(result.type).toEqual('success');
   });
 
@@ -62,7 +62,7 @@ describe('Organization Service', () => {
     (api.put as jest.Mock).mockResolvedValue({ data: mockPayload });
 
     const result = await organizationQuery.updateOrganization('1', mockPayload);
-    expect(api.put).toHaveBeenCalled();
+    expect(api.put).toHaveBeenCalledWith('/v1/organizations/1/', mockPayload, expect.any(Object));
     expect(result.type).toEqual('success');
   });
 
@@ -70,7 +70,7 @@ describe('Organization Service', () => {
     (api.delete as jest.Mock).mockResolvedValue({ status: 204 });
 
     const result = await organizationQuery.deleteOrganization('1');
-    expect(api.delete).toHaveBeenCalled();
+    expect(api.delete).toHaveBeenCalledWith('/v1/organizations/1/', expect.any(Object));
     expect(result.type).toEqual('success');
   });
 

--- a/src/shared/services/tests/product.spec.ts
+++ b/src/shared/services/tests/product.spec.ts
@@ -9,21 +9,21 @@ describe('ProductQuery', () => {
   it('getAllProducts should call api.get with the right URL', async () => {
     const organizationId = '1';
     await productQuery.getAllProducts(organizationId);
-    expect(api.get).toHaveBeenCalledWith(`/organizations/${organizationId}/products/`);
+    expect(api.get).toHaveBeenCalledWith(`/v1/organizations/${organizationId}/products/`);
   });
 
   it('getProductById should call api.get with the right URL', async () => {
     const organizationId = '1';
     const id = '2';
     await productQuery.getProductById(organizationId, id);
-    expect(api.get).toHaveBeenCalledWith(`/organizations/${organizationId}/products/${id}/`);
+    expect(api.get).toHaveBeenCalledWith(`/v1/organizations/${organizationId}/products/${id}/`);
   });
 
   it('updateProduct should call api.get with the right URL', async () => {
     const organizationId = 1;
     const id = '2';
     await productQuery.updateProduct(id, { name: 'teste', organizationId });
-    expect(api.put).toHaveBeenCalledWith(`/organizations/${organizationId}/products/${id}/`, {
+    expect(api.put).toHaveBeenCalledWith(`/v1/organizations/${organizationId}/products/${id}/`, {
       name: 'teste',
       organizationId: 1
     });
@@ -33,14 +33,14 @@ describe('ProductQuery', () => {
     const organizationId = '1';
     const productId = '2';
     await productQuery.getAllRepositories(organizationId, productId);
-    expect(api.get).toHaveBeenCalledWith(`/organizations/${organizationId}/products/${productId}/repositories`);
+    expect(api.get).toHaveBeenCalledWith(`/v1/organizations/${organizationId}/products/${productId}/repositories`);
   });
 
   it('getProductMeasuresHistory should call api.get with the right URL', async () => {
     const organizationId = '1';
     const productId = '2';
     await productQuery.getProductMeasuresHistory(organizationId, productId);
-    expect(api.get).toHaveBeenCalledWith(`organizations/${organizationId}/repository/${productId}/history/measures/`);
+    expect(api.get).toHaveBeenCalledWith(`/v1/organizations/${organizationId}/repository/${productId}/history/measures/`);
   });
 
   it('postPreConfig should call api.post with the right URL and data', async () => {
@@ -57,7 +57,7 @@ describe('ProductQuery', () => {
     await productQuery.postPreConfig(organizationId, productId, data);
 
     expect(api.post).toHaveBeenCalledWith(
-      `/organizations/${organizationId}/products/${productId}/create/release-config/`,
+      `/v1/organizations/${organizationId}/products/${productId}/create/release-config/`,
       data
     );
   });
@@ -67,7 +67,7 @@ describe('ProductQuery', () => {
     const productId = '2';
     await productQuery.getProductCurrentPreConfig(organizationId, productId);
     expect(api.get).toHaveBeenCalledWith(
-      `organizations/${organizationId}/products/${productId}/current/release-config/`
+      `/v1/organizations/${organizationId}/products/${productId}/current/release-config/`
     );
   });
 
@@ -76,7 +76,7 @@ describe('ProductQuery', () => {
     const projectId = '2';
     await productQuery.getPreConfigEntitiesRelationship(organizationId, projectId);
     expect(api.get).toHaveBeenCalledWith(
-      `organizations/${organizationId}/products/${projectId}/entity-relationship-tree/`
+      `/v1/organizations/${organizationId}/products/${projectId}/entity-relationship-tree/`
     );
   });
 
@@ -90,7 +90,7 @@ describe('ProductQuery', () => {
       changes: []
     } as unknown as ReleaseGoal;
     await productQuery.createProductGoal(organizationId, productId, data);
-    expect(api.post).toHaveBeenCalledWith(`organizations/${organizationId}/products/${productId}/create/goal/`, data);
+    expect(api.post).toHaveBeenCalledWith(`/v1/organizations/${organizationId}/products/${productId}/create/goal/`, data);
   });
 
   it('updateReleaseEndDate should call api.put with the right URL and data', async () => {
@@ -100,7 +100,7 @@ describe('ProductQuery', () => {
     const releaseId = '3';
     await productQuery.updateReleaseEndDate(organizationId, projectId, repositoryId, {});
     expect(api.put).toHaveBeenCalledWith(
-      `organizations/${organizationId}/products/${projectId}/release/${releaseId}/update-end-at/`,
+      `/v1/organizations/${organizationId}/products/${projectId}/release/${releaseId}/update-end-at/`,
       {}
     );
   });
@@ -110,7 +110,7 @@ describe('ProductQuery', () => {
     const productId = '2';
 
     await productQuery.createProductRelease(organizationId, productId, {});
-    expect(api.post).toHaveBeenCalledWith(`organizations/${organizationId}/products/${productId}/release/`, {});
+    expect(api.post).toHaveBeenCalledWith(`/v1/organizations/${organizationId}/products/${productId}/release/`, {});
   });
 
   it('getIsReleaseValid should call api.get with the right URL', async () => {
@@ -126,7 +126,7 @@ describe('ProductQuery', () => {
 
     await productQuery.getIsReleaseValid(organizationId, productId, form);
     expect(api.get).toHaveBeenCalledWith(
-      `organizations/${organizationId}/products/${productId}/release/is-valid/?nome=${form.release_name}&dt-inicial=${form.start_at}&dt-final=${form.end_at}`
+      `/v1/organizations/${organizationId}/products/${productId}/release/is-valid/?nome=${form.release_name}&dt-inicial=${form.start_at}&dt-final=${form.end_at}`
     );
   });
 
@@ -136,7 +136,7 @@ describe('ProductQuery', () => {
     const repositoryId = '3';
     await productQuery.getCharacteristicsLatestValues(organizationId, productId, repositoryId);
     expect(api.get).toHaveBeenCalledWith(
-      `organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/characteristics/`
+      `/v1/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/characteristics/`
     );
   });
 
@@ -146,7 +146,7 @@ describe('ProductQuery', () => {
     const repositoryId = '3';
     await productQuery.getSubcharacteristicsLatestValues(organizationId, productId, repositoryId);
     expect(api.get).toHaveBeenCalledWith(
-      `organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/subcharacteristics/`
+      `/v1/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/subcharacteristics/`
     );
   });
 
@@ -156,7 +156,7 @@ describe('ProductQuery', () => {
     const repositoryId = '3';
     await productQuery.getMeasuresLatestValues(organizationId, productId, repositoryId);
     expect(api.get).toHaveBeenCalledWith(
-      `organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/measures/`
+      `/v1/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/measures/`
     );
   });
 
@@ -167,14 +167,14 @@ describe('ProductQuery', () => {
     const repositoryId = '3';
     await productQuery.getMetricsLatestValues(organizationId, productId, repositoryId);
     expect(api.get).toHaveBeenCalledWith(
-      `organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/metrics/`
+      `/v1/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/latest-values/metrics/`
     );
   });
   it('should return a proper AxiosRequestConfig object', () => {
     const organizationId = '1';
     const productId = '2';
     const expectedResult = {
-      url: `organizations/${organizationId}/products/${productId}/release/`,
+      url: `/v1/organizations/${organizationId}/products/${productId}/release/`,
       method: 'get'
     };
 
@@ -185,7 +185,7 @@ describe('ProductQuery', () => {
     const organizationId = '1';
     const productId = '2';
     await productQuery.getCurrentReleaseGoal(organizationId, productId);
-    expect(api.get).toHaveBeenCalledWith(`organizations/${organizationId}/products/${productId}/current/goal/`);
+    expect(api.get).toHaveBeenCalledWith(`/v1/organizations/${organizationId}/products/${productId}/current/goal/`);
   });
 
   it('getCompareGoalAccomplished should call api.get with the right URL', async () => {
@@ -193,7 +193,7 @@ describe('ProductQuery', () => {
     const productId = '2';
     const releaseId = 3;
     await productQuery.getCompareGoalAccomplished(organizationId, productId, releaseId);
-    expect(api.get).toHaveBeenCalledWith(`organizations/${organizationId}/products/${productId}/all/goal/`, {
+    expect(api.get).toHaveBeenCalledWith(`/v1/organizations/${organizationId}/products/${productId}/all/goal/`, {
       params: { release_id: releaseId }
     });
   });
@@ -203,7 +203,7 @@ describe('ProductQuery', () => {
     const productId = '2';
     await productQuery.getProductRepositoriesTsqmiHistory(organizationId, productId);
     expect(api.get).toHaveBeenCalledWith(
-      `organizations/${organizationId}/products/${productId}/repositories-tsqmi-historical-values/`
+      `/v1/organizations/${organizationId}/products/${productId}/repositories-tsqmi-historical-values/`
     );
   });
 
@@ -212,7 +212,7 @@ describe('ProductQuery', () => {
     const productId = '2';
     await productQuery.getProductRepositoriesLatestTsqmi(organizationId, productId);
     expect(api.get).toHaveBeenCalledWith(
-      `organizations/${organizationId}/products/${productId}/repositories-tsqmi-latest-values/`
+      `/v1/organizations/${organizationId}/products/${productId}/repositories-tsqmi-latest-values/`
     );
   });
 
@@ -220,7 +220,7 @@ describe('ProductQuery', () => {
     const organizationId = '1';
     const productId = '2';
     await productQuery.getProductDefaultPreConfig(organizationId, productId);
-    expect(api.get).toHaveBeenCalledWith(`organizations/${organizationId}/products/${productId}/default/pre-config/`);
+    expect(api.get).toHaveBeenCalledWith(`/v1/organizations/${organizationId}/products/${productId}/default/pre-config/`);
   });
 
   it('getCurrentGoal should call api.get with the right URL', async () => {
@@ -228,7 +228,7 @@ describe('ProductQuery', () => {
     const id = '2';
     const releaseId = 3;
     await productQuery.getCurrentGoal(organizationId, id, releaseId);
-    expect(api.get).toHaveBeenCalledWith(`organizations/${organizationId}/products/${id}/current/goal/`, {
+    expect(api.get).toHaveBeenCalledWith(`/v1/organizations/${organizationId}/products/${id}/current/goal/`, {
       params: { release_id: releaseId }
     });
   });
@@ -236,7 +236,7 @@ describe('ProductQuery', () => {
   it('createProduct should call api.post with the right URL', async () => {
     const organizationId = 1;
     await productQuery.createProduct({ name: 'teste', organizationId });
-    expect(api.post).toHaveBeenCalledWith(`/organizations/${organizationId}/products/`, {
+    expect(api.post).toHaveBeenCalledWith(`/v1/organizations/${organizationId}/products/`, {
       name: 'teste',
       organizationId
     });
@@ -255,7 +255,7 @@ describe('ProductQuery', () => {
 
     const result = await productQuery.createProduct({ name: 'teste', organizationId });
 
-    expect(api.post).toHaveBeenCalledWith(`/organizations/${organizationId}/products/`, {
+    expect(api.post).toHaveBeenCalledWith(`/v1/organizations/${organizationId}/products/`, {
       name: 'teste',
       organizationId
     });
@@ -289,7 +289,7 @@ describe('ProductQuery', () => {
 
     const result = await productQuery.deleteProduct(id, organizationId);
 
-    expect(api.delete).toHaveBeenCalledWith(`/organizations/${organizationId}/products/${id}/`);
+    expect(api.delete).toHaveBeenCalledWith(`/v1/organizations/${organizationId}/products/${id}/`);
     expect(result.type).toBe('error');
     expect((result as any).error).toBe(error);
   });
@@ -301,7 +301,7 @@ describe('ProductQuery', () => {
 
     await productQuery.getReleaseAnalysisDataByReleaseId(organizationId, productId, releaseId);
     expect(api.get).toHaveBeenCalledWith(
-      `organizations/${organizationId}/products/${productId}/release/${releaseId}/analysis_data`
+      `/v1/organizations/${organizationId}/products/${productId}/release/${releaseId}/analysis_data`
     );
   });
 

--- a/src/shared/services/tests/repository.spec.ts
+++ b/src/shared/services/tests/repository.spec.ts
@@ -1,29 +1,32 @@
-import axios from 'axios';
 import { repository } from '../repository';
+import api from '../api';
 
 jest.mock('../api', () => ({
-  api: {
-    interceptors: {
-      request: {
-        use: jest.fn()
-      },
-      response: {
-        use: jest.fn()
-      }
-    }
-    // Adicione outros métodos conforme necessário
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn()
   }
 }));
 
-// Mock Axios
-jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
+// Mock do Auth para que getAuthHeaders resolva sem chamar a rede real.
+jest.mock('@services/Auth', () => ({
+  getAccessToken: jest.fn().mockResolvedValue({ type: 'success', value: { key: 'mock-token' } })
+}));
+
+const mockedApi = api as jest.Mocked<typeof api>;
 
 describe('Repository', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('createRepository', () => {
     it('should handle an error when creating a repository', async () => {
       // Simule uma falha na API
-      mockedAxios.post.mockRejectedValue(new Error('Failed to create repository'));
+      (mockedApi.post as jest.Mock).mockRejectedValue(new Error('Failed to create repository'));
 
       // Execute o método
       const result = await repository.createRepository('org1', 'prod1', { name: 'Test Repo', platform: 'GitHub' });
@@ -36,7 +39,7 @@ describe('Repository', () => {
   describe('updateRepository', () => {
     it('should handle an error when updating a repository', async () => {
       // Simule uma falha na API
-      mockedAxios.put.mockRejectedValue(new Error('Failed to update repository'));
+      (mockedApi.put as jest.Mock).mockRejectedValue(new Error('Failed to update repository'));
 
       // Execute o método
       const result = await repository.updateRepository('org1', 'prod1', 'repo1', {
@@ -52,7 +55,7 @@ describe('Repository', () => {
   describe('deleteRepository', () => {
     it('should handle an error when deleting a repository', async () => {
       // Simule uma falha na API
-      mockedAxios.delete.mockRejectedValue(new Error('Failed to delete repository'));
+      (mockedApi.delete as jest.Mock).mockRejectedValue(new Error('Failed to delete repository'));
 
       // Execute o método
       const result = await repository.deleteRepository('org1', 'prod1', 'repo1');
@@ -65,7 +68,7 @@ describe('Repository', () => {
   describe('getHistoricalData', () => {
     it('should handle an error when fetching historical data', async () => {
       // Simule uma falha na API
-      mockedAxios.get.mockRejectedValue(new Error('Failed to fetch historical data'));
+      (mockedApi.get as jest.Mock).mockRejectedValue(new Error('Failed to fetch historical data'));
 
       // Execute o método
       const result = await repository.getHistoricalData({
@@ -77,6 +80,28 @@ describe('Repository', () => {
 
       // Verifique o resultado
       expect(result.type).toEqual('error');
+    });
+  });
+
+  describe('versiona rotas com /v1', () => {
+    it('getRepository should call api.get with the /v1 prefixed URL', async () => {
+      (mockedApi.get as jest.Mock).mockResolvedValue({ data: { id: 'repo1' } });
+
+      await repository.getRepository('org1', 'prod1', 'repo1');
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/v1/organizations/org1/products/prod1/repositories/repo1/');
+    });
+
+    it('createRepository should call api.post with the /v1 prefixed URL', async () => {
+      (mockedApi.post as jest.Mock).mockResolvedValue({ data: {} });
+
+      await repository.createRepository('org1', 'prod1', { name: 'Test Repo', platform: 'GitHub' });
+
+      expect(mockedApi.post).toHaveBeenCalledWith(
+        '/v1/organizations/org1/products/prod1/repositories/',
+        { name: 'Test Repo', platform: 'GitHub', imported: false },
+        expect.any(Object)
+      );
     });
   });
 });

--- a/src/shared/services/tests/subCharacteristics.spec.ts
+++ b/src/shared/services/tests/subCharacteristics.spec.ts
@@ -19,7 +19,7 @@ describe('SubCharacteristics service', () => {
     const response = await subCharacteristics.getRepository(organizationId, productId, repositoryId);
 
     expect(api.get).toHaveBeenCalledWith(
-      `organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/`
+      `/v1/organizations/${organizationId}/products/${productId}/repositories/${repositoryId}/`
     );
     expect(response).toBe(expectedResponse);
   });
@@ -38,7 +38,7 @@ describe('SubCharacteristics service', () => {
     const response = await subCharacteristics.getHistoricalCharacteristics(props);
 
     expect(api.get).toHaveBeenCalledWith(
-      `organizations/${props.organizationId}` +
+      `/v1/organizations/${props.organizationId}` +
         `/products/${props.productId}/repositories/${props.repositoryId}` +
         `/historical-values/${props.entity}/`
     );

--- a/src/shared/services/tests/user.spec.ts
+++ b/src/shared/services/tests/user.spec.ts
@@ -24,7 +24,7 @@ describe('User Service', () => {
 
     const result = await userService.getAllUsers();
 
-    expect(api.get).toHaveBeenCalledWith('/accounts/users/', {
+    expect(api.get).toHaveBeenCalledWith('/v1/accounts/users/', {
       headers: { Authorization: 'Token mock-token' }
     });
     expect(result).toEqual({ type: 'success', value: mockData });
@@ -48,7 +48,7 @@ describe('User Service', () => {
 
     const result = await userService.getUserRepos('codigo-123');
 
-    expect(api.get).toHaveBeenCalledWith('/accounts/user-repos', { params: { code: 'codigo-123' } });
+    expect(api.get).toHaveBeenCalledWith('/v1/accounts/user-repos', { params: { code: 'codigo-123' } });
     expect(result).toEqual({ type: 'success', value: mockData });
   });
 

--- a/src/shared/services/user.ts
+++ b/src/shared/services/user.ts
@@ -32,7 +32,7 @@ export const getAllUsers = async (): Promise<Result<UserResult>> => {
 
     const token = tokenResult.value.key;
 
-    const response = await api.get('/accounts/users/', {
+    const response = await api.get('/v1/accounts/users/', {
       headers: {
         Authorization: `Token ${token}`
       }
@@ -60,7 +60,7 @@ type GetUserRepoResponse = {
 
 export async function getUserRepos(code: string): Promise<Result<GetUserRepoResponse>> {
   try {
-    const response = await api.get('/accounts/user-repos', { params: { code } });
+    const response = await api.get('/v1/accounts/user-repos', { params: { code } });
     return { type: 'success', value: response.data };
   } catch (err) {
     const error = err as AxiosError;


### PR DESCRIPTION
## Motivação

O front chamava a API sem o prefixo de versao e levava 404 em producao. A API responde em `/api/v1/`, mas as rotas eram montadas so com `/api`. Verificado direto na producao: `POST /api/accounts/login/` retornava 404, enquanto `POST /api/v1/accounts/login/` respondia e `GET /api/v1/` dava 200.

A correcao mantem o `/v1` explicito em cada rota, em vez de embutir no default da baseURL. Assim, quando algum endpoint precisar de v2, da pra trocar rota a rota, sem um default global implicito que mascararia todas as chamadas e viraria divida tecnica.

## Mudanças

- `/v1` prefixado em cada rota dos 7 services (Auth, user, organization, product, repository, balanceMatrix, subCharacteristics).
- `baseURL` passa a terminar em `/api` em todas as configuracoes: `.env.example`, `Dockerfile` (ARG default) e `docker-compose.yml`.
- `NEXT_PUBLIC_API_URL` no `.env.example` tambem alinhada para `/api` (a variavel segue sem uso no codigo, isso e divida a parte, mas nao fazia sentido manter `/v1` nela).
- Chamadas absolutas a `api.github.com` ficaram inalteradas (nao levam `/v1`).
- Feito em TDD: commit RED (testes passam a exigir `/v1` e falham) e commit GREEN (o fix faz passar).

## Status Checklist

- [x] Test
- [ ] Lint
- [x] Development

## Screenshots

N/A. Mudanca na camada de servico, sem alteracao visual.

## Execução

- Suite completa verde: `npx jest src/ --watchAll=false` (438 testes, 97 suites).
- Em producao, com a `baseURL` terminando em `/api`, o login volta a responder (`POST /api/v1/accounts/login/`). So confirmar que o `SERVICE_URL` de prod nao tem `/v1` residual nem barra final.
- Lint: o fix nao adiciona erros novos; os warnings/erros existentes nos arquivos sao pre-existentes e fora do escopo desta issue.

Closes #46
