### PR TITLE
fix(test): fixa o relogio no snapshot de Repository

### DIFF
--- a/src/pages/products/[product]/repositories/[repository]/tests/Repository.spec.tsx
+++ b/src/pages/products/[product]/repositories/[repository]/tests/Repository.spec.tsx
@@ -26,6 +26,19 @@ jest.mock('next/router', () => ({
 }));
 
 describe('<Repository />', () => {
+  // O TsqmiBadge compara created_at do mock contra Date.now() pra decidir se a
+  // analise esta "stale" (> 30 dias). Sem fixar o relogio, o snapshot passa a
+  // renderizar o alerta de stale assim que a data real ultrapassa 30 dias do
+  // created_at do mock, quebrando o teste com o tempo. Fixamos o agora num
+  // ponto dentro da janela pra manter o render deterministico.
+  beforeAll(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-05-25T00:00:00Z').getTime());
+  });
+
+  afterAll(() => {
+    (Date.now as jest.Mock).mockRestore();
+  });
+
   it('Should render correctly', () => {
     const { container } = render(
       <OrganizationProvider>


### PR DESCRIPTION
## Problema

O check `pipeline` da develop passou a falhar sozinho (sem ninguem mexer) por volta de 19/06. O teste de snapshot de `<Repository />` compara o `created_at` fixo do mock (2026-05-20) contra `Date.now()` real, via `TsqmiBadge`. Quando a data real ultrapassou 30 dias do mock, o componente passou a renderizar o alerta de `badge-stale` e o snapshot (gerado antes dos 30 dias) quebrou.

Isso travava o CI de qualquer PR aberto contra a develop.

## Correcao

Fixa `Date.now()` num ponto dentro da janela de 30 dias (`2026-05-25`) no `beforeAll`, restaurando no `afterAll`. O render fica deterministico e bate o snapshot ja versionado, sem regenerar.

## Verificacao

Suite completa verde local: 97 suites, 438 testes, 57 snapshots.