### PR TITLE
fix(docker): rodar Front em modo producao no deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
-FROM node:20-alpine
+# ============================================================
+# Build de producao do Front (Next.js 12). Multi-stage:
+#   builder -> instala deps + next build (gera o .next otimizado)
+#   runner  -> NODE_ENV=production + next start (serve o build pronto)
+#
+# Em producao o Next NAO compila pagina on-demand: a home responde de
+# imediato. O `next dev` que rodava aqui antes compilava `/` na primeira
+# request, estourava o proxy_read_timeout do nginx (504) e reprovava o
+# smoke test do deploy.
+# ============================================================
 
-# Set environment
-ENV NODE_ENV=development
-ENV PORT=3000
+# ---------- builder ----------
+FROM node:20-alpine AS builder
 
-# Install dependencies needed for node-gyp and others if necessary
-RUN apk add --no-cache libc6-compat
-
-# build-args inlined no bundle (build-time). O default e o ambiente de
-# desenvolvimento; o valor de cada ambiente vem via --build-arg no CI.
+# build-args inlined no bundle (next.config `env`, avaliado em build-time).
+# Os defaults sao de desenvolvimento; cada ambiente sobrescreve via --build-arg.
 ARG SERVICE_URL=http://localhost:8080/api
 ARG LOGIN_REDIRECT_URL
 ARG GITHUB_CLIENT_ID
@@ -17,19 +22,38 @@ ENV LOGIN_REDIRECT_URL=$LOGIN_REDIRECT_URL
 ENV GITHUB_CLIENT_ID=$GITHUB_CLIENT_ID
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# Dependencias nativas (node-gyp e afins).
+RUN apk add --no-cache libc6-compat
+
 WORKDIR /usr/src
 
-# Copy package management files
+# Camada de dependencias: so invalida quando o lockfile muda.
 COPY package.json pnpm-lock.yaml* ./
+RUN npm install -g pnpm@9.0.0 && pnpm install --frozen-lockfile
 
-# Install dependencies
-RUN npm install -g pnpm && pnpm install --frozen-lockfile
-
-# Copy application code
+# Codigo + build de producao.
 COPY . .
+RUN pnpm build
 
-# Expose port
+# ---------- runner ----------
+FROM node:20-alpine AS runner
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN apk add --no-cache libc6-compat && npm install -g pnpm@9.0.0
+
+WORKDIR /usr/src
+
+# Artefatos que o `next start` precisa: build, deps, manifestos e estaticos.
+COPY --from=builder /usr/src/node_modules ./node_modules
+COPY --from=builder /usr/src/.next ./.next
+COPY --from=builder /usr/src/public ./public
+COPY --from=builder /usr/src/package.json ./package.json
+COPY --from=builder /usr/src/next.config.js ./next.config.js
+
 EXPOSE 3000
 
-# Start development server
-CMD ["pnpm", "dev"]
+# Servidor de producao (paginas ja compiladas, sem on-demand).
+CMD ["pnpm", "start"]


### PR DESCRIPTION
## Problema
O job `Deploy Prod (self-hosted)` do Service vinha falhando no **smoke test** (run #28330380701). Backend, API, migrate e Docker subiam normais; o furo era a home do Front.

Causa raiz: o Dockerfile rodava `pnpm dev` (`NODE_ENV=development`). Em modo dev o Next compila cada pagina on-demand. O smoke batia `GET /`, a home comecava a compilar, passava dos 60s de `proxy_read_timeout` do nginx, que devolvia **504** e reprovava o deploy.

## Fix
Dockerfile multi-stage: `next build` no builder + `next start` no runner, com `NODE_ENV=production`. As paginas ja vem compiladas, a home responde de imediato.

## Validacao (local, via docker build + run)
- build passa limpo (todas as paginas estaticas geradas)
- home `/` responde **HTTP 200 em ~3ms** (era 504 apos 60s)
- log confirma `next start`, sem compilacao on-demand

## Nota fora de escopo (nao corrigida aqui, mas precisa de atencao)
O `docker-publish.yml` nao passa `--build-arg` pra nenhum dos 3 ARGs do Dockerfile, e o `next build` inlina esses valores no bundle em build-time (antes, em `next dev`, eram lidos em runtime). Com os defaults atuais, a producao sobe quebrada:
- `SERVICE_URL` = `http://localhost:8080/api` -> API aponta pra localhost
- `LOGIN_REDIRECT_URL` = vazio -> redirect de login quebrado
- `GITHUB_CLIENT_ID` = vazio -> OAuth do GitHub fora do ar

Pra producao funcionar de fato, o CI precisa passar esses 3 via `--build-arg` (ou `secrets`). Fica pra um PR separado.