### PR TITLE
fix(front): injetar credenciais de OAuth/API no build de producao

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    # `closed` dispara tambem em PR fechado SEM merge. So buildar/publicar
+    # quando o PR foi de fato mergeado, senao um PR recusado publicaria imagem.
+    if: github.event.pull_request.merged == true
 
     steps:
       - name: Checkout do código
@@ -28,3 +31,18 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/front:latest
+          # Estes valores sao inlinados no bundle em build-time (Next.js), entao
+          # PRECISAM existir aqui, nao adianta injetar no container em runtime.
+          # Configurados como Repository Variables (Settings > Secrets and
+          # variables > Actions > Variables). Sao publicos (client_id aparece na
+          # URL de OAuth; URLs sao publicas), por isso variables e nao secrets.
+          # GH_CLIENT_ID: o prefixo GITHUB_ e reservado pelo Actions, por isso o
+          # nome encurtado. Tem que ser O MESMO client_id configurado no backend
+          # (Service, .service.env GITHUB_CLIENT_ID), senao da "Client ID
+          # mismatch" no endpoint /github/validate. Enquanto a variable nao
+          # existir, cai no fallback e o build sai como antes (sem regressao).
+          build-args: |
+            SERVICE_URL=${{ vars.SERVICE_URL || 'http://localhost:8080/api' }}
+            NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_API_URL || 'http://localhost:8080/api' }}
+            LOGIN_REDIRECT_URL=${{ vars.LOGIN_REDIRECT_URL }}
+            GITHUB_CLIENT_ID=${{ vars.GH_CLIENT_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,17 @@
 # ---------- builder ----------
 FROM node:20-alpine AS builder
 
-# build-args inlined no bundle (next.config `env`, avaliado em build-time).
-# Os defaults sao de desenvolvimento; cada ambiente sobrescreve via --build-arg.
+# build-args inlined no bundle (next.config `env` + prefixo NEXT_PUBLIC_,
+# avaliados em build-time). Os defaults sao de desenvolvimento; cada ambiente
+# sobrescreve via --build-arg (ver .github/workflows/docker-publish.yml).
+# NEXT_PUBLIC_API_URL e a baseURL do axios no browser (src/shared/services/
+# api.ts); sem ela as chamadas de API caem no proprio dominio do front.
 ARG SERVICE_URL=http://localhost:8080/api
+ARG NEXT_PUBLIC_API_URL=http://localhost:8080/api
 ARG LOGIN_REDIRECT_URL
 ARG GITHUB_CLIENT_ID
 ENV SERVICE_URL=$SERVICE_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ENV LOGIN_REDIRECT_URL=$LOGIN_REDIRECT_URL
 ENV GITHUB_CLIENT_ID=$GITHUB_CLIENT_ID
 ENV NEXT_TELEMETRY_DISABLED=1


### PR DESCRIPTION
## Problema
O `docker-publish.yml` (build da imagem de producao) nao passava nenhum `--build-arg`. Como o `next build` inlina as variaveis no bundle em build-time, `GITHUB_CLIENT_ID`, `LOGIN_REDIRECT_URL` e `SERVICE_URL` saiam vazios (ou no default localhost). E `NEXT_PUBLIC_API_URL` (baseURL do axios no browser, `src/shared/services/api.ts`) nao tinha nem `ARG` no Dockerfile.

Efeito em producao: o login com GitHub montava a URL de autorizacao com `client_id=` vazio e o GitHub recusava; as chamadas de API caiam no dominio do proprio front.

O backend ja esta configurado e funcional (o endpoint `/github/validate` confirma credenciais validas no backend); faltava propagar o client_id pro front.

## Fix
- `Dockerfile`: adiciona `ARG`/`ENV` `NEXT_PUBLIC_API_URL`, que faltava de todo.
- `docker-publish.yml`: passa os 4 valores como build-args, lidos de Repository Variables (`SERVICE_URL`, `NEXT_PUBLIC_API_URL`, `LOGIN_REDIRECT_URL`, `GH_CLIENT_ID`). Sao publicos (o client_id aparece na URL de OAuth; as URLs sao publicas), por isso variables e nao secrets. O `GH_CLIENT_ID` precisa ser o mesmo client_id do backend, senao da `Client ID mismatch` no `/github/validate`.
- Aproveitando o arquivo: o job rodava em `pull_request: closed`, que dispara tambem em PR fechado SEM merge (um PR recusado publicaria imagem). Adicionado `if: github.event.pull_request.merged == true`.

## Sem quebra
Enquanto as variables nao forem criadas: `LOGIN_REDIRECT_URL` e `GH_CLIENT_ID` saem vazios como antes; `SERVICE_URL` e `NEXT_PUBLIC_API_URL` caem no fallback localhost (melhora sobre o estado atual, nao regride).

## Pra ativar (config no repo, fora deste PR)
Settings > Secrets and variables > Actions > Variables: criar `SERVICE_URL`, `NEXT_PUBLIC_API_URL`, `LOGIN_REDIRECT_URL`, `GH_CLIENT_ID`. O `GH_CLIENT_ID` igual ao do backend.

## Validacao
`docker build` com build-args de teste; os valores aparecem inlinados nos chunks JS gerados (grep no `.next`).