### PR TITLE
fix: loging timeout e testes para o mesmo

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+process.env.NODE_ENV = 'test';
+
 const nextJest = require('next/jest');
 
 // Carrega o ambiente do Next.js (lê next.config.js e arquivos .env)
@@ -45,6 +47,8 @@ const customJestConfig = {
   // Mapeia os aliases para os caminhos dos arquivos
   moduleNameMapper: {
     ...aliases,
+    '^react$': require.resolve('react'),         
+    '^react-dom$': require.resolve('react-dom'),  
     '\\.svg$': '<rootDir>/__mocks__/svgMock.js',
     '^next/image$': '<rootDir>/__mocks__/next/ImageMock.js'
   },

--- a/src/shared/contexts/Auth/Auth.context.tsx
+++ b/src/shared/contexts/Auth/Auth.context.tsx
@@ -139,7 +139,7 @@ export const AuthProvider = ({ children }: { children: JSX.Element }) => {
   );
 
 
-  useEffect(() => {
+useEffect(() => {
     const checkSessionTime = () => {
       const loginTime = localStorage.getItem('login_timestamp');
 
@@ -166,12 +166,13 @@ export const AuthProvider = ({ children }: { children: JSX.Element }) => {
       }
     };
 
-    // Checa a condição a cada 1 minuto
+    checkSessionTime();
+
+    // Checa a condição a cada 1 minuto para o caso do usuário ficar ocioso
     const interval = setInterval(checkSessionTime, 60000);
 
     return () => clearInterval(interval);
   }, [logout, session, token]);
-
   useEffect(() => {
     const params = new URLSearchParams(globalThis.location.search);
     const code = params.get('code');


### PR DESCRIPTION
## Motivação

A funcionalidade de tempo limite (timeout) de sessão não estava a funcionar conforme o esperado. Devido à dependência do `router` na função de `logout`, o `useEffect` responsável pela contagem do tempo era desmontado e remontado cada vez que o utilizador navegava entre as páginas. Como consequência, o intervalo de verificação (que aguardava 60 segundos para correr a primeira vez) era constantemente reiniciado, impedindo que a sessão expirasse caso o utilizador não ficasse totalmente inativo na mesma página durante 2 horas seguidas. Além disso, havia um erro de encaminhamento quando a API devolvia `401 Unauthorized`.

## Mudanças

- Invocação imediata da função `checkSessionTime()` no ficheiro `Auth.context.tsx` antes do registo do `setInterval`, garantindo a validação da sessão nas mudanças de rota.
- Correção do redirecionamento abrupto no intercetor do ficheiro `api.ts` de `/auth` para `/`, evitando que o utilizador se depare com um erro 404 (página não encontrada) quando o token expira.

## Status Checklist

- [x] Test
- [x] Lint
- [x] Development

## Execução

Para testar a implementação mais rapidamente:

1. No ficheiro `Auth.context.tsx`, altere temporariamente a variável `limitMs` para 60 segundos (`60 * 1000`) e a variável `warningMs` para 30 segundos (`30 * 1000`).
2. Altere também o tempo do `setInterval` no final do `useEffect` para 20 segundos (`20000`).
3. Inicie o servidor, faça o login na plataforma e aguarde sem mexer no rato/teclado.
4. Ao fim de 40 segundos deverá surgir o modal/toast de aviso ("Sua sessão expirará em breve!").
5. Aos 60 segundos, a plataforma deverá executar o logout automático e reencaminhar o utilizador para a página inicial (`/`).
6. **Nota:** Lembre-se de reverter as variáveis de tempo para as 2 horas regulamentares após o teste antes do merge final!