### PR TITLE
fix(landing): restaura landing page removida em revert anterior + namespace i18n

### DIFF
--- a/n18n.config.js
+++ b/n18n.config.js
@@ -5,6 +5,7 @@ export const ni18nConfig = {
   supportedLngs,
   ns: [
     'translation',
+    'landing',
     'home',
     'about',
     'sidebar',

--- a/public/locales/en/landing.json
+++ b/public/locales/en/landing.json
@@ -1,0 +1,85 @@
+{
+  "meta": {
+    "title": "MeasureSoftGram",
+    "description": "Measure your software quality objectively, based on metrics collected from your own pipeline."
+  },
+  "nav": {
+    "howItWorks": "How it works",
+    "value": "Why use it",
+    "docs": "Documentation",
+    "enter": "Sign in"
+  },
+  "hero": {
+    "badge": "Evidence based software quality",
+    "title": "Measure your software quality objectively",
+    "subtitle": "MeasureSoftGram collects metrics from your repository, applies a configurable quality model and turns the numbers into clear dashboards to track how your releases evolve.",
+    "primaryCta": "Open the system",
+    "secondaryCta": "Read the documentation"
+  },
+  "howItWorks": {
+    "title": "How it works",
+    "subtitle": "From code to a quality indicator in four steps.",
+    "steps": {
+      "register": {
+        "title": "Register your product",
+        "description": "Create your organization and register the software products you want to track."
+      },
+      "connect": {
+        "title": "Connect the repositories",
+        "description": "Link the product repositories and define what should be measured in each of them."
+      },
+      "collect": {
+        "title": "Collect metrics in CI",
+        "description": "Continuous integration sends your pipeline metrics on every analysis, with no manual work."
+      },
+      "visualize": {
+        "title": "Track the dashboards",
+        "description": "Visualize characteristics, subcharacteristics and quality evolution across releases."
+      }
+    }
+  },
+  "value": {
+    "title": "Why use MeasureSoftGram",
+    "subtitle": "Quality decisions backed by data, not perception.",
+    "items": {
+      "model": {
+        "title": "Configurable quality model",
+        "description": "Set weights per characteristic and subcharacteristic to reflect your product priorities."
+      },
+      "dashboards": {
+        "title": "Quality dashboards",
+        "description": "Objective, visual indicators that make the state of the software easy to share with the team."
+      },
+      "releases": {
+        "title": "Release comparison",
+        "description": "Define reference values and track whether each release moves toward or away from the quality goal."
+      }
+    }
+  },
+  "community": {
+    "title": "Learn more about the project",
+    "subtitle": "MeasureSoftGram is an open project maintained by the community.",
+    "docs": {
+      "title": "Documentation",
+      "description": "Usage guides, architecture and how to integrate MeasureSoftGram into your workflow.",
+      "cta": "Read the docs"
+    },
+    "repos": {
+      "title": "Repositories",
+      "description": "Explore the source code of the project components and contribute.",
+      "cta": "View on GitHub"
+    },
+    "app": {
+      "title": "Dashboards",
+      "description": "Open the system and visualize the quality of your products.",
+      "cta": "Open the system"
+    }
+  },
+  "footer": {
+    "tagline": "Multidimensional software quality analysis.",
+    "docs": "Documentation",
+    "repos": "Repositories",
+    "enter": "Sign in",
+    "rights": "Open source academic project."
+  }
+}

--- a/public/locales/pt/landing.json
+++ b/public/locales/pt/landing.json
@@ -1,0 +1,85 @@
+{
+  "meta": {
+    "title": "MeasureSoftGram",
+    "description": "Meça a qualidade do seu software de forma objetiva, com base em métricas coletadas do seu próprio pipeline."
+  },
+  "nav": {
+    "howItWorks": "Como funciona",
+    "value": "Por que usar",
+    "docs": "Documentação",
+    "enter": "Entrar"
+  },
+  "hero": {
+    "badge": "Qualidade de software baseada em evidência",
+    "title": "Meça a qualidade do seu software de forma objetiva",
+    "subtitle": "O MeasureSoftGram coleta métricas do seu repositório, aplica um modelo de qualidade configurável e transforma os números em dashboards claros para acompanhar a evolução das suas releases.",
+    "primaryCta": "Acessar o sistema",
+    "secondaryCta": "Ver a documentação"
+  },
+  "howItWorks": {
+    "title": "Como funciona",
+    "subtitle": "Do código ao indicador de qualidade em quatro passos.",
+    "steps": {
+      "register": {
+        "title": "Cadastre seu produto",
+        "description": "Crie sua organização e registre os produtos de software que deseja acompanhar."
+      },
+      "connect": {
+        "title": "Conecte os repositórios",
+        "description": "Associe os repositórios do produto e defina o que será medido em cada um deles."
+      },
+      "collect": {
+        "title": "Colete as métricas no CI",
+        "description": "A integração contínua envia as métricas do seu pipeline a cada nova análise, sem trabalho manual."
+      },
+      "visualize": {
+        "title": "Acompanhe os dashboards",
+        "description": "Visualize características, subcaracterísticas e a evolução da qualidade entre releases."
+      }
+    }
+  },
+  "value": {
+    "title": "Por que usar o MeasureSoftGram",
+    "subtitle": "Decisões de qualidade sustentadas por dados, não por percepção.",
+    "items": {
+      "model": {
+        "title": "Modelo de qualidade configurável",
+        "description": "Defina pesos por característica e subcaracterística para refletir as prioridades do seu produto."
+      },
+      "dashboards": {
+        "title": "Dashboards de qualidade",
+        "description": "Indicadores objetivos e visuais que tornam o estado do software fácil de comunicar para o time."
+      },
+      "releases": {
+        "title": "Comparação entre releases",
+        "description": "Defina valores de referência e acompanhe se cada release se aproxima ou se afasta da meta de qualidade."
+      }
+    }
+  },
+  "community": {
+    "title": "Conheça mais sobre o projeto",
+    "subtitle": "O MeasureSoftGram é um projeto aberto e mantido pela comunidade.",
+    "docs": {
+      "title": "Documentação",
+      "description": "Guias de uso, arquitetura e como integrar o MeasureSoftGram ao seu fluxo.",
+      "cta": "Ler a documentação"
+    },
+    "repos": {
+      "title": "Repositórios",
+      "description": "Explore o código dos componentes do projeto e contribua.",
+      "cta": "Ver no GitHub"
+    },
+    "app": {
+      "title": "Dashboards",
+      "description": "Acesse o sistema e visualize a qualidade dos seus produtos.",
+      "cta": "Acessar o sistema"
+    }
+  },
+  "footer": {
+    "tagline": "Análise multidimensional da qualidade de software.",
+    "docs": "Documentação",
+    "repos": "Repositórios",
+    "enter": "Entrar no sistema",
+    "rights": "Projeto acadêmico de código aberto."
+  }
+}

--- a/src/pages/index.page.ts
+++ b/src/pages/index.page.ts
@@ -1,1 +1,3 @@
-export { default } from './auth/index.page';
+// A rota raiz serve a landing. Re-exporta tambem getStaticProps para que o meta
+// (Open Graph / Twitter) seja resolvido no servidor tambem em "/".
+export { default, getStaticProps } from './landing/index.page';

--- a/src/pages/landing/Landing.tsx
+++ b/src/pages/landing/Landing.tsx
@@ -1,0 +1,104 @@
+import React, { ReactElement } from 'react';
+import Head from 'next/head';
+import type { GetStaticProps } from 'next';
+import { Box } from '@mui/material';
+import { loadTranslations } from 'ni18n';
+import { NextPageWithLayout } from '@pages/_app.next';
+import { ni18nConfig } from '../../../n18n.config';
+import { LandingHeader } from './components/LandingHeader';
+import { HeroSection } from './components/HeroSection';
+import { HowItWorksSection } from './components/HowItWorksSection';
+import { ValuePropsSection } from './components/ValuePropsSection';
+import { CommunitySection } from './components/CommunitySection';
+import { LandingFooter } from './components/LandingFooter';
+import { SITE_URL, OG_IMAGE_PATH } from './constants';
+
+// Locale usado para resolver as tags do <head> no servidor. O crawler de
+// OpenGraph (WhatsApp, Slack, redes sociais) le o HTML renderizado pelo
+// servidor, onde o `t()` do react-i18next ainda nao resolveu. Por isso o meta
+// e montado a partir das strings carregadas em build time, e nao via hook.
+const META_LOCALE = 'pt';
+
+interface LandingMeta {
+  metaTitle: string;
+  metaDescription: string;
+  heroTitle: string;
+  ogImage: string;
+}
+
+interface LandingProps {
+  meta: LandingMeta;
+}
+
+const Landing: React.FC<LandingProps> = ({ meta }) => {
+  const pageTitle = `${meta.metaTitle} - ${meta.heroTitle}`;
+
+  return (
+    <>
+      <Head>
+        <title>{pageTitle}</title>
+        <meta name="description" content={meta.metaDescription} />
+
+        {/* Open Graph: preview do link em WhatsApp, Slack, LinkedIn, etc. */}
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={meta.metaDescription} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={SITE_URL} />
+        <meta property="og:image" content={meta.ogImage} />
+        <meta property="og:site_name" content={meta.metaTitle} />
+
+        {/* Twitter Card: preview do link no X/Twitter. */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={meta.metaDescription} />
+        <meta name="twitter:image" content={meta.ogImage} />
+      </Head>
+      <Box component="main" sx={{ backgroundColor: '#ffffff' }}>
+        <LandingHeader />
+        <HeroSection />
+        <HowItWorksSection />
+        <ValuePropsSection />
+        <CommunitySection />
+        <LandingFooter />
+      </Box>
+    </>
+  );
+};
+
+// getLayout: a landing renderiza sem o layout autenticado padrao.
+(Landing as NextPageWithLayout<LandingProps>).getLayout = function getLayout(page: ReactElement) {
+  return page;
+};
+
+// Resolve as strings do <head> no servidor (build time). Sem isso, o crawler
+// de OpenGraph receberia as chaves cruas ("meta.title - hero.title"), porque o
+// react-i18next so resolve apos a hidratacao no cliente.
+export const getStaticProps: GetStaticProps<LandingProps> = async () => {
+  const serverState = await loadTranslations(ni18nConfig, META_LOCALE, 'landing');
+  // __ni18n_server__ e o contrato interno do ni18n para hidratar o cliente.
+  // eslint-disable-next-line no-underscore-dangle
+  const landingResources: any = serverState?.__ni18n_server__?.resources?.[META_LOCALE]?.landing ?? {};
+
+  const metaTitle = landingResources?.meta?.title ?? 'MeasureSoftGram';
+  const metaDescription =
+    landingResources?.meta?.description ??
+    'Meca a qualidade do seu software de forma objetiva, com base em metricas coletadas do seu proprio pipeline.';
+  const heroTitle = landingResources?.hero?.title ?? metaTitle;
+
+  // og:image precisa ser uma URL absoluta para o crawler conseguir buscar.
+  const ogImage = new URL(OG_IMAGE_PATH, SITE_URL).toString();
+
+  return {
+    props: {
+      ...serverState,
+      meta: {
+        metaTitle,
+        metaDescription,
+        heroTitle,
+        ogImage
+      }
+    }
+  };
+};
+
+export default Landing;

--- a/src/pages/landing/components/CommunitySection.tsx
+++ b/src/pages/landing/components/CommunitySection.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'react-i18next';
+import { Grid, Button } from '@mui/material';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import { EXTERNAL_LINKS, APP_ENTRY_ROUTE } from '../constants';
+import { LandingSection } from './LandingSection';
+import { FeatureCard } from './FeatureCard';
+
+export const CommunitySection: React.FC = () => {
+  const { t } = useTranslation('landing');
+  const router = useRouter();
+
+  const cards = [
+    {
+      key: 'docs',
+      Icon: MenuBookIcon,
+      onClick: () => window.open(EXTERNAL_LINKS.docs, '_blank', 'noopener,noreferrer')
+    },
+    {
+      key: 'repos',
+      Icon: GitHubIcon,
+      onClick: () => window.open(EXTERNAL_LINKS.repositories, '_blank', 'noopener,noreferrer')
+    },
+    {
+      key: 'app',
+      Icon: DashboardIcon,
+      onClick: () => router.push(APP_ENTRY_ROUTE)
+    }
+  ];
+
+  return (
+    <LandingSection
+      id="community"
+      title={t('community.title')}
+      subtitle={t('community.subtitle')}
+    >
+      {cards.map(({ key, Icon, onClick }) => (
+        <Grid item xs={12} md={4} key={key}>
+          <FeatureCard
+            title={t(`community.${key}.title`)}
+            description={t(`community.${key}.description`)}
+            paperSx={{
+              p: 4,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-start'
+            }}
+            badgeSx={{
+              width: 52,
+              height: 52,
+              borderRadius: '14px',
+              backgroundColor: '#2B4D6F',
+              color: '#ffffff'
+            }}
+            titleSx={{ fontSize: '1.1rem' }}
+            descriptionSx={{ fontSize: '0.98rem', mb: 3, flexGrow: 1 }}
+            badge={<Icon />}
+          >
+            <Button
+              variant="text"
+              onClick={onClick}
+              sx={{ color: '#2B4D6F', fontWeight: 600, px: 0 }}
+            >
+              {t(`community.${key}.cta`)}
+            </Button>
+          </FeatureCard>
+        </Grid>
+      ))}
+    </LandingSection>
+  );
+};
+
+export default CommunitySection;

--- a/src/pages/landing/components/FeatureCard.tsx
+++ b/src/pages/landing/components/FeatureCard.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Box, Paper, Typography, SxProps, Theme } from '@mui/material';
+
+interface FeatureCardProps {
+  title: string;
+  description: string;
+  /** Conteudo do badge: numero do passo (How it works) ou icone (demais). */
+  badge: React.ReactNode;
+  /** Estilo extra do Paper (ex.: padding, layout em coluna). */
+  paperSx?: SxProps<Theme>;
+  /** Estilo extra do badge (tamanho, raio, cores). */
+  badgeSx?: SxProps<Theme>;
+  /** Estilo extra do titulo (ex.: fontSize maior). */
+  titleSx?: SxProps<Theme>;
+  /** Estilo extra da descricao (ex.: mb + flexGrow no card de comunidade). */
+  descriptionSx?: SxProps<Theme>;
+  /** Conteudo opcional renderizado apos a descricao (ex.: botao de CTA). */
+  children?: React.ReactNode;
+}
+
+/**
+ * Cartao compartilhado das secoes da landing: Paper com borda arredondada,
+ * um badge (numero ou icone), titulo e descricao. Cada secao ajusta os
+ * detalhes visuais via *Sx para preservar o layout original.
+ */
+export const FeatureCard: React.FC<FeatureCardProps> = ({
+  title,
+  description,
+  badge,
+  paperSx,
+  badgeSx,
+  titleSx,
+  descriptionSx,
+  children
+}) => (
+  <Paper
+    elevation={0}
+    sx={{
+      height: '100%',
+      borderRadius: '16px',
+      border: '1px solid #e6e9ef',
+      backgroundColor: '#ffffff',
+      ...paperSx
+    }}
+  >
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        mb: 2,
+        ...badgeSx
+      }}
+    >
+      {badge}
+    </Box>
+    <Typography sx={{ color: '#1f2d3d', fontWeight: 700, mb: 1, ...titleSx }}>
+      {title}
+    </Typography>
+    <Typography sx={{ color: '#5a6472', fontSize: '0.95rem', ...descriptionSx }}>
+      {description}
+    </Typography>
+    {children}
+  </Paper>
+);
+
+export default FeatureCard;

--- a/src/pages/landing/components/HeroSection.tsx
+++ b/src/pages/landing/components/HeroSection.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'react-i18next';
+import { Box, Container, Typography, Stack, Button, Chip } from '@mui/material';
+import MSGButton from '../../../components/idv/buttons/MSGButton';
+import { EXTERNAL_LINKS, APP_ENTRY_ROUTE } from '../constants';
+
+const LOGO_SOURCE = '/images/svg/logo.svg';
+
+export const HeroSection: React.FC = () => {
+  const { t } = useTranslation('landing');
+  const router = useRouter();
+
+  return (
+    <Box
+      component="section"
+      sx={{
+        background: 'linear-gradient(180deg, #f4f7fb 0%, #ffffff 100%)',
+        py: { xs: 6, md: 10 }
+      }}
+    >
+      <Container maxWidth="lg">
+        <Stack
+          direction={{ xs: 'column', md: 'row' }}
+          spacing={{ xs: 4, md: 6 }}
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          <Box flex={1}>
+            <Chip
+              label={t('hero.badge')}
+              sx={{
+                mb: 2,
+                backgroundColor: '#e7eef6',
+                color: '#2B4D6F',
+                fontWeight: 600
+              }}
+            />
+            <Typography
+              variant="h2"
+              component="h1"
+              sx={{
+                color: '#1f2d3d',
+                fontWeight: 800,
+                fontSize: { xs: '2.2rem', md: '3rem' },
+                lineHeight: 1.15,
+                mb: 2
+              }}
+            >
+              {t('hero.title')}
+            </Typography>
+            <Typography
+              sx={{ color: '#5a6472', fontSize: '1.15rem', mb: 4, maxWidth: 560 }}
+            >
+              {t('hero.subtitle')}
+            </Typography>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+              <MSGButton onClick={() => router.push(APP_ENTRY_ROUTE)} width={220}>
+                {t('hero.primaryCta')}
+              </MSGButton>
+              <Button
+                variant="outlined"
+                href={EXTERNAL_LINKS.docs}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{
+                  height: '50px',
+                  borderColor: '#2B4D6F',
+                  color: '#2B4D6F',
+                  fontWeight: 500,
+                  '&:hover': { borderColor: '#165870', backgroundColor: '#eef3f8' }
+                }}
+              >
+                {t('hero.secondaryCta')}
+              </Button>
+            </Stack>
+          </Box>
+
+          <Box
+            flex={1}
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            sx={{ width: '100%' }}
+          >
+            <Box
+              sx={{
+                p: { xs: 4, md: 6 },
+                borderRadius: '24px',
+                backgroundColor: '#ffffff',
+                boxShadow: '0 18px 40px rgba(43, 77, 111, 0.12)',
+                display: 'flex',
+                justifyContent: 'center'
+              }}
+            >
+              <Image src={LOGO_SOURCE} alt="MeasureSoftGram" width={240} height={240} priority />
+            </Box>
+          </Box>
+        </Stack>
+      </Container>
+    </Box>
+  );
+};
+
+export default HeroSection;

--- a/src/pages/landing/components/HowItWorksSection.tsx
+++ b/src/pages/landing/components/HowItWorksSection.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Grid } from '@mui/material';
+import { LandingSection } from './LandingSection';
+import { FeatureCard } from './FeatureCard';
+
+const STEP_KEYS = ['register', 'connect', 'collect', 'visualize'] as const;
+
+export const HowItWorksSection: React.FC = () => {
+  const { t } = useTranslation('landing');
+
+  return (
+    <LandingSection
+      id="how-it-works"
+      title={t('howItWorks.title')}
+      subtitle={t('howItWorks.subtitle')}
+    >
+      {STEP_KEYS.map((key, index) => (
+        <Grid item xs={12} sm={6} md={3} key={key}>
+          <FeatureCard
+            title={t(`howItWorks.steps.${key}.title`)}
+            description={t(`howItWorks.steps.${key}.description`)}
+            paperSx={{ p: 3 }}
+            badgeSx={{
+              width: 44,
+              height: 44,
+              borderRadius: '12px',
+              backgroundColor: '#2B4D6F',
+              color: '#ffffff',
+              fontWeight: 700,
+              fontSize: '1.1rem'
+            }}
+            badge={index + 1}
+          />
+        </Grid>
+      ))}
+    </LandingSection>
+  );
+};
+
+export default HowItWorksSection;

--- a/src/pages/landing/components/LandingFooter.tsx
+++ b/src/pages/landing/components/LandingFooter.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'react-i18next';
+import { Box, Container, Typography, Stack, Link as MuiLink } from '@mui/material';
+import { EXTERNAL_LINKS, APP_ENTRY_ROUTE } from '../constants';
+
+const LOGO_SOURCE = '/images/svg/logo_white.svg';
+
+export const LandingFooter: React.FC = () => {
+  const { t } = useTranslation('landing');
+  const router = useRouter();
+
+  return (
+    <Box component="footer" sx={{ backgroundColor: '#2B4D6F', color: '#ffffff', py: 5 }}>
+      <Container maxWidth="lg">
+        <Stack
+          direction={{ xs: 'column', md: 'row' }}
+          spacing={3}
+          justifyContent="space-between"
+          alignItems={{ xs: 'flex-start', md: 'center' }}
+        >
+          <Box display="flex" alignItems="center" gap={1.5}>
+            <Image src={LOGO_SOURCE} alt="MeasureSoftGram" width={32} height={32} />
+            <Box>
+              <Typography sx={{ fontWeight: 700 }}>MeasureSoftGram</Typography>
+              <Typography sx={{ fontSize: '0.85rem', opacity: 0.8 }}>
+                {t('footer.tagline')}
+              </Typography>
+            </Box>
+          </Box>
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={3}>
+            <MuiLink
+              href={EXTERNAL_LINKS.docs}
+              target="_blank"
+              rel="noopener noreferrer"
+              underline="hover"
+              sx={{ color: '#ffffff', fontWeight: 500 }}
+            >
+              {t('footer.docs')}
+            </MuiLink>
+            <MuiLink
+              href={EXTERNAL_LINKS.repositories}
+              target="_blank"
+              rel="noopener noreferrer"
+              underline="hover"
+              sx={{ color: '#ffffff', fontWeight: 500 }}
+            >
+              {t('footer.repos')}
+            </MuiLink>
+            <MuiLink
+              component="button"
+              type="button"
+              onClick={() => router.push(APP_ENTRY_ROUTE)}
+              underline="hover"
+              sx={{ color: '#ffffff', fontWeight: 500 }}
+            >
+              {t('footer.enter')}
+            </MuiLink>
+          </Stack>
+        </Stack>
+
+        <Typography sx={{ mt: 4, fontSize: '0.8rem', opacity: 0.7 }}>
+          {t('footer.rights')}
+        </Typography>
+      </Container>
+    </Box>
+  );
+};
+
+export default LandingFooter;

--- a/src/pages/landing/components/LandingHeader.tsx
+++ b/src/pages/landing/components/LandingHeader.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'react-i18next';
+import { AppBar, Toolbar, Box, Button, Container, Link as MuiLink } from '@mui/material';
+import MSGButton from '../../../components/idv/buttons/MSGButton';
+import { EXTERNAL_LINKS, APP_ENTRY_ROUTE } from '../constants';
+
+const LOGO_SOURCE = '/images/svg/logo.svg';
+
+export const LandingHeader: React.FC = () => {
+  const { t } = useTranslation('landing');
+  const router = useRouter();
+
+  return (
+    <AppBar
+      position="sticky"
+      elevation={0}
+      sx={{ backgroundColor: '#ffffff', borderBottom: '1px solid #e6e9ef' }}
+    >
+      <Container maxWidth="lg">
+        <Toolbar disableGutters sx={{ justifyContent: 'space-between', gap: 2 }}>
+          <Box display="flex" alignItems="center" gap={1.5}>
+            <Image src={LOGO_SOURCE} alt="MeasureSoftGram" width={36} height={36} />
+            <Box
+              component="span"
+              sx={{ color: '#2B4D6F', fontWeight: 700, fontSize: '1.1rem', letterSpacing: '0.5px' }}
+            >
+              MeasureSoftGram
+            </Box>
+          </Box>
+
+          <Box
+            display={{ xs: 'none', md: 'flex' }}
+            alignItems="center"
+            gap={3}
+          >
+            <MuiLink href="#how-it-works" underline="none" sx={{ color: '#4a4a4a', fontWeight: 500 }}>
+              {t('nav.howItWorks')}
+            </MuiLink>
+            <MuiLink href="#value" underline="none" sx={{ color: '#4a4a4a', fontWeight: 500 }}>
+              {t('nav.value')}
+            </MuiLink>
+            <MuiLink
+              href={EXTERNAL_LINKS.docs}
+              target="_blank"
+              rel="noopener noreferrer"
+              underline="none"
+              sx={{ color: '#4a4a4a', fontWeight: 500 }}
+            >
+              {t('nav.docs')}
+            </MuiLink>
+          </Box>
+
+          <Box display="flex" alignItems="center">
+            <Box display={{ xs: 'block', sm: 'none' }}>
+              <Button
+                variant="contained"
+                onClick={() => router.push(APP_ENTRY_ROUTE)}
+                sx={{ backgroundColor: '#2B4D6F', '&:hover': { backgroundColor: '#165870' } }}
+              >
+                {t('nav.enter')}
+              </Button>
+            </Box>
+            <Box display={{ xs: 'none', sm: 'block' }}>
+              <MSGButton onClick={() => router.push(APP_ENTRY_ROUTE)} width={140}>
+                {t('nav.enter')}
+              </MSGButton>
+            </Box>
+          </Box>
+        </Toolbar>
+      </Container>
+    </AppBar>
+  );
+};
+
+export default LandingHeader;

--- a/src/pages/landing/components/LandingSection.tsx
+++ b/src/pages/landing/components/LandingSection.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Box, Container, Typography, Grid, SxProps, Theme } from '@mui/material';
+
+interface LandingSectionProps {
+  id: string;
+  title: string;
+  subtitle: string;
+  /** Estilo extra aplicado ao Box raiz da secao (ex.: backgroundColor). */
+  sx?: SxProps<Theme>;
+  /** Cartoes da secao, renderizados dentro do Grid container. */
+  children: React.ReactNode;
+}
+
+/**
+ * Casca compartilhada das secoes da landing: Box <section>, Container,
+ * cabecalho centralizado (titulo + subtitulo) e o Grid container que
+ * agrupa os cartoes. Mantem o visual identico ao das secoes originais.
+ */
+export const LandingSection: React.FC<LandingSectionProps> = ({
+  id,
+  title,
+  subtitle,
+  sx,
+  children
+}) => (
+  <Box component="section" id={id} sx={{ py: { xs: 6, md: 10 }, ...sx }}>
+    <Container maxWidth="lg">
+      <Box textAlign="center" mb={{ xs: 4, md: 6 }}>
+        <Typography
+          variant="h4"
+          component="h2"
+          sx={{ color: '#1f2d3d', fontWeight: 800, mb: 1 }}
+        >
+          {title}
+        </Typography>
+        <Typography sx={{ color: '#5a6472', fontSize: '1.05rem' }}>
+          {subtitle}
+        </Typography>
+      </Box>
+
+      <Grid container spacing={3}>
+        {children}
+      </Grid>
+    </Container>
+  </Box>
+);
+
+export default LandingSection;

--- a/src/pages/landing/components/ValuePropsSection.tsx
+++ b/src/pages/landing/components/ValuePropsSection.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Grid } from '@mui/material';
+import TuneIcon from '@mui/icons-material/Tune';
+import InsightsIcon from '@mui/icons-material/Insights';
+import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
+import { LandingSection } from './LandingSection';
+import { FeatureCard } from './FeatureCard';
+
+const ITEMS = [
+  { key: 'model', Icon: TuneIcon },
+  { key: 'dashboards', Icon: InsightsIcon },
+  { key: 'releases', Icon: CompareArrowsIcon }
+] as const;
+
+export const ValuePropsSection: React.FC = () => {
+  const { t } = useTranslation('landing');
+
+  return (
+    <LandingSection
+      id="value"
+      title={t('value.title')}
+      subtitle={t('value.subtitle')}
+      sx={{ backgroundColor: '#f4f7fb' }}
+    >
+      {ITEMS.map(({ key, Icon }) => (
+        <Grid item xs={12} md={4} key={key}>
+          <FeatureCard
+            title={t(`value.items.${key}.title`)}
+            description={t(`value.items.${key}.description`)}
+            paperSx={{ p: 4 }}
+            badgeSx={{
+              width: 52,
+              height: 52,
+              borderRadius: '14px',
+              backgroundColor: '#e7eef6',
+              color: '#2B4D6F'
+            }}
+            titleSx={{ fontSize: '1.1rem' }}
+            descriptionSx={{ fontSize: '0.98rem' }}
+            badge={<Icon />}
+          />
+        </Grid>
+      ))}
+    </LandingSection>
+  );
+};
+
+export default ValuePropsSection;

--- a/src/pages/landing/constants.ts
+++ b/src/pages/landing/constants.ts
@@ -1,0 +1,23 @@
+// Links externos publicos exibidos na landing.
+// Centralizados aqui para facilitar a manutencao caso as URLs publicas mudem.
+
+export const EXTERNAL_LINKS = {
+  // Documentacao publica (GitHub Pages do repositorio central de documentacao
+  // do projeto, MeasureSoftGram-Docs, onde vivem as paginas de comunidade).
+  docs: 'https://fga-eps-mds.github.io/MeasureSoftGram-Docs/',
+  // Organizacao no GitHub que reune os repositorios do projeto.
+  repositories: 'https://github.com/fga-eps-mds',
+};
+
+// Rota interna de acesso ao sistema. Usuario logado e redirecionado ao
+// dashboard pelo proprio fluxo de autenticacao; deslogado cai no login.
+export const APP_ENTRY_ROUTE = '/auth';
+
+// URL publica canonica da landing, usada nas tags Open Graph / Twitter Card
+// para que o preview do link (WhatsApp, Slack, redes sociais) aponte sempre
+// para o dominio de producao.
+export const SITE_URL = 'https://msgram.lappis.rocks/';
+
+// Imagem usada no preview do link. Aponta para um asset PNG existente do
+// projeto (logo) para garantir que o crawler de OpenGraph encontre algo valido.
+export const OG_IMAGE_PATH = '/images/png/logo.png';

--- a/src/pages/landing/index.page.ts
+++ b/src/pages/landing/index.page.ts
@@ -1,0 +1,3 @@
+// getStaticProps precisa ser re-exportado a partir do modulo da pagina para o
+// Next reconhece-lo e resolver o meta no servidor (build time).
+export { default, getStaticProps } from './Landing';

--- a/src/pages/landing/test/CommunitySection.spec.tsx
+++ b/src/pages/landing/test/CommunitySection.spec.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CommunitySection } from '../components/CommunitySection';
+import { EXTERNAL_LINKS, APP_ENTRY_ROUTE } from '../constants';
+
+const mockPush = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    pathname: '/',
+    query: {},
+    asPath: '/',
+  }),
+}));
+
+describe('CommunitySection', () => {
+  const originalOpen = window.open;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.open = jest.fn();
+  });
+
+  afterAll(() => {
+    window.open = originalOpen;
+  });
+
+  it('o card de documentacao abre o link externo de docs em nova aba', () => {
+    render(<CommunitySection />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'community.docs.cta' }));
+
+    expect(window.open).toHaveBeenCalledWith(
+      EXTERNAL_LINKS.docs,
+      '_blank',
+      'noopener,noreferrer'
+    );
+  });
+
+  it('o card de repositorios abre a organizacao do GitHub em nova aba', () => {
+    render(<CommunitySection />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'community.repos.cta' }));
+
+    expect(window.open).toHaveBeenCalledWith(
+      EXTERNAL_LINKS.repositories,
+      '_blank',
+      'noopener,noreferrer'
+    );
+  });
+
+  it('o card de acesso ao app navega para a rota interna de entrada', () => {
+    render(<CommunitySection />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'community.app.cta' }));
+
+    expect(mockPush).toHaveBeenCalledWith(APP_ENTRY_ROUTE);
+  });
+});

--- a/src/pages/landing/test/FeatureCard.spec.tsx
+++ b/src/pages/landing/test/FeatureCard.spec.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { FeatureCard } from '../components/FeatureCard';
+
+describe('FeatureCard', () => {
+  it('renderiza badge, titulo, descricao e o children recebido', () => {
+    render(
+      <FeatureCard
+        badge={<span>1</span>}
+        title="Titulo do cartao"
+        description="Descricao do cartao"
+      >
+        <button type="button">Acessar</button>
+      </FeatureCard>
+    );
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('Titulo do cartao')).toBeInTheDocument();
+    expect(screen.getByText('Descricao do cartao')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Acessar' })).toBeInTheDocument();
+  });
+});

--- a/src/pages/landing/test/LandingFooter.spec.tsx
+++ b/src/pages/landing/test/LandingFooter.spec.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LandingFooter } from '../components/LandingFooter';
+import { EXTERNAL_LINKS, APP_ENTRY_ROUTE } from '../constants';
+
+const mockPush = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    pathname: '/',
+    query: {},
+    asPath: '/',
+  }),
+}));
+
+describe('LandingFooter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('expoe os links externos publicos de docs e repositorios', () => {
+    render(<LandingFooter />);
+
+    const docsLink = screen.getByRole('link', { name: 'footer.docs' });
+    expect(docsLink).toHaveAttribute('href', EXTERNAL_LINKS.docs);
+    expect(docsLink).toHaveAttribute('target', '_blank');
+
+    const reposLink = screen.getByRole('link', { name: 'footer.repos' });
+    expect(reposLink).toHaveAttribute('href', EXTERNAL_LINKS.repositories);
+    expect(reposLink).toHaveAttribute('target', '_blank');
+  });
+
+  it('o botao de entrada do rodape navega para a rota interna de acesso', () => {
+    render(<LandingFooter />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'footer.enter' }));
+
+    expect(mockPush).toHaveBeenCalledWith(APP_ENTRY_ROUTE);
+  });
+});

--- a/src/pages/landing/test/LandingHeader.spec.tsx
+++ b/src/pages/landing/test/LandingHeader.spec.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LandingHeader } from '../components/LandingHeader';
+import { APP_ENTRY_ROUTE } from '../constants';
+
+const mockPush = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    pathname: '/',
+    query: {},
+    asPath: '/',
+  }),
+}));
+
+describe('LandingHeader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renderiza os dois botoes de entrada (mobile e desktop)', () => {
+    render(<LandingHeader />);
+
+    const enterButtons = screen.getAllByRole('button', { name: 'nav.enter' });
+    expect(enterButtons).toHaveLength(2);
+  });
+
+  it('cada botao de entrada navega para a rota interna de acesso', () => {
+    render(<LandingHeader />);
+
+    const enterButtons = screen.getAllByRole('button', { name: 'nav.enter' });
+    enterButtons.forEach((button) => {
+      fireEvent.click(button);
+    });
+
+    expect(mockPush).toHaveBeenCalledTimes(enterButtons.length);
+    expect(mockPush).toHaveBeenCalledWith(APP_ENTRY_ROUTE);
+  });
+});

--- a/src/pages/landing/test/LandingLayout.spec.tsx
+++ b/src/pages/landing/test/LandingLayout.spec.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Landing from '../Landing';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    pathname: '/',
+    query: {},
+    asPath: '/',
+  }),
+}));
+
+describe('Landing.getLayout', () => {
+  it('retorna a propria pagina sem envolve-la em um layout autenticado', () => {
+    const page = <div data-testid="landing-page" />;
+
+    expect(Landing.getLayout).toBeDefined();
+    expect(Landing.getLayout!(page)).toBe(page);
+  });
+});

--- a/src/pages/landing/test/LandingSection.spec.tsx
+++ b/src/pages/landing/test/LandingSection.spec.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LandingSection } from '../components/LandingSection';
+
+describe('LandingSection', () => {
+  it('renderiza titulo, subtitulo e os cartoes recebidos como children', () => {
+    const { container } = render(
+      <LandingSection
+        id="secao-exemplo"
+        title="Titulo da secao"
+        subtitle="Subtitulo da secao"
+      >
+        <div data-testid="card-filho">conteudo do cartao</div>
+      </LandingSection>
+    );
+
+    expect(screen.getByText('Titulo da secao')).toBeInTheDocument();
+    expect(screen.getByText('Subtitulo da secao')).toBeInTheDocument();
+    expect(screen.getByTestId('card-filho')).toBeInTheDocument();
+
+    const section = container.querySelector('section');
+    expect(section).toHaveAttribute('id', 'secao-exemplo');
+  });
+});

--- a/src/pages/landing/test/landing.spec.tsx
+++ b/src/pages/landing/test/landing.spec.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { loadTranslations } from 'ni18n';
+import Landing, { getStaticProps } from '../Landing';
+import { EXTERNAL_LINKS } from '../constants';
+
+const mockedLoadTranslations = loadTranslations as jest.MockedFunction<typeof loadTranslations>;
+
+const mockPush = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    pathname: '/',
+    query: {},
+    asPath: '/',
+  }),
+}));
+
+// next/head depende do HeadManagerContext do App do Next para escrever no
+// document.head, contexto ausente no ambiente de teste. Renderizamos os filhos
+// num container inline para conseguir consultar as tags de meta resolvidas no
+// servidor.
+jest.mock('next/head', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="head">{children}</div>
+  ),
+}));
+
+// ni18n.loadTranslations cria uma instancia real do i18next, que depende do
+// react-i18next (globalmente mockado no jestSetup). Mockamos a funcao para
+// devolver um server state realista e exercitar a resolucao do meta no
+// getStaticProps sem acoplar ao mock global de i18n.
+jest.mock('ni18n', () => ({
+  loadTranslations: jest.fn(async () => ({
+    __ni18n_server__: {
+      resources: {
+        pt: {
+          landing: {
+            meta: {
+              title: 'MeasureSoftGram',
+              description:
+                'Meca a qualidade do seu software de forma objetiva, com base em metricas coletadas do seu proprio pipeline.',
+            },
+            hero: { title: 'Meca a qualidade do seu software de forma objetiva' },
+          },
+        },
+      },
+      ns: ['landing'],
+      lng: 'pt',
+    },
+  })),
+}));
+
+// Meta resolvido no servidor (via getStaticProps) e injetado como prop. O
+// componente nao usa mais t() para o <head>, justamente para que o crawler de
+// OpenGraph leia texto real no HTML renderizado pelo servidor.
+const META_KEY_PREFIX = 'meta.';
+const HERO_KEY_PREFIX = 'hero.';
+const HERO_TITLE = 'Meca a qualidade do seu software de forma objetiva';
+
+const meta = {
+  metaTitle: 'MeasureSoftGram',
+  metaDescription: 'Meca a qualidade do seu software de forma objetiva.',
+  heroTitle: HERO_TITLE,
+  ogImage: 'https://msgram.lappis.rocks/images/png/logo.png',
+};
+
+describe('Landing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renderiza as secoes principais da landing', () => {
+    render(<Landing meta={meta} />);
+
+    expect(screen.getByText('hero.title')).toBeInTheDocument();
+    expect(screen.getByText('howItWorks.title')).toBeInTheDocument();
+    expect(screen.getByText('value.title')).toBeInTheDocument();
+    expect(screen.getByText('community.title')).toBeInTheDocument();
+  });
+
+  it('o CTA principal do hero leva o usuario para /auth', () => {
+    render(<Landing meta={meta} />);
+
+    const ctas = screen.getAllByRole('button', { name: 'hero.primaryCta' });
+    fireEvent.click(ctas[0]);
+
+    expect(mockPush).toHaveBeenCalledWith('/auth');
+  });
+
+  it('expoe os links externos publicos esperados', () => {
+    render(<Landing meta={meta} />);
+
+    const docsLinks = screen.getAllByRole('link', { name: 'nav.docs' });
+    expect(docsLinks[0]).toHaveAttribute('href', EXTERNAL_LINKS.docs);
+    expect(docsLinks[0]).toHaveAttribute('target', '_blank');
+  });
+
+  it('renderiza title e meta description com texto real (nao chave crua)', () => {
+    const { container } = render(<Landing meta={meta} />);
+
+    const expectedTitle = `${meta.metaTitle} - ${meta.heroTitle}`;
+
+    const title = container.querySelector('title');
+    expect(title?.textContent).toBe(expectedTitle);
+    expect(title?.textContent).not.toContain(META_KEY_PREFIX);
+    expect(title?.textContent).not.toContain(HERO_KEY_PREFIX);
+
+    const description = container.querySelector('meta[name="description"]');
+    expect(description).toHaveAttribute('content', meta.metaDescription);
+    expect(description?.getAttribute('content')).not.toContain(META_KEY_PREFIX);
+  });
+
+  it('expoe as tags Open Graph e Twitter Card para o preview do link', () => {
+    const { container } = render(<Landing meta={meta} />);
+
+    const expectedTitle = `${meta.metaTitle} - ${meta.heroTitle}`;
+
+    expect(container.querySelector('meta[property="og:title"]')).toHaveAttribute(
+      'content',
+      expectedTitle
+    );
+    expect(container.querySelector('meta[property="og:description"]')).toHaveAttribute(
+      'content',
+      meta.metaDescription
+    );
+    expect(container.querySelector('meta[property="og:type"]')).toHaveAttribute(
+      'content',
+      'website'
+    );
+    expect(container.querySelector('meta[property="og:url"]')).toHaveAttribute(
+      'content',
+      'https://msgram.lappis.rocks/'
+    );
+    expect(container.querySelector('meta[property="og:image"]')).toHaveAttribute(
+      'content',
+      meta.ogImage
+    );
+    expect(container.querySelector('meta[property="og:site_name"]')).toHaveAttribute(
+      'content',
+      meta.metaTitle
+    );
+
+    expect(container.querySelector('meta[name="twitter:card"]')).toHaveAttribute(
+      'content',
+      'summary_large_image'
+    );
+    expect(container.querySelector('meta[name="twitter:title"]')).toHaveAttribute(
+      'content',
+      expectedTitle
+    );
+    expect(container.querySelector('meta[name="twitter:description"]')).toHaveAttribute(
+      'content',
+      meta.metaDescription
+    );
+    expect(container.querySelector('meta[name="twitter:image"]')).toHaveAttribute(
+      'content',
+      meta.ogImage
+    );
+  });
+
+  it('getStaticProps resolve o meta no servidor a partir das traducoes (sem chave crua)', async () => {
+    const result: any = await getStaticProps({});
+
+    const resolvedMeta = result.props.meta;
+
+    // Texto real carregado do namespace landing, nao a chave i18n.
+    expect(resolvedMeta.metaTitle).toBe('MeasureSoftGram');
+    expect(resolvedMeta.metaTitle).not.toContain(META_KEY_PREFIX);
+    expect(resolvedMeta.metaDescription).not.toContain(META_KEY_PREFIX);
+    expect(resolvedMeta.metaDescription.length).toBeGreaterThan(20);
+    expect(resolvedMeta.heroTitle).toBe(HERO_TITLE);
+    expect(resolvedMeta.heroTitle).not.toContain(HERO_KEY_PREFIX);
+
+    // og:image precisa ser uma URL absoluta para o crawler buscar a imagem.
+    expect(resolvedMeta.ogImage).toBe(meta.ogImage);
+  });
+
+  it('getStaticProps usa os defaults quando o namespace landing nao traz as strings', async () => {
+    // Simula um server state sem o namespace landing resolvido (build sem as
+    // traducoes carregadas). Cada `??` do meta deve cair no valor default.
+    mockedLoadTranslations.mockResolvedValueOnce({
+      __ni18n_server__: { resources: {}, ns: ['landing'], lng: 'pt' },
+    } as any);
+
+    const result: any = await getStaticProps({});
+
+    const resolvedMeta = result.props.meta;
+
+    expect(resolvedMeta.metaTitle).toBe('MeasureSoftGram');
+    expect(resolvedMeta.metaDescription).toBe(
+      'Meca a qualidade do seu software de forma objetiva, com base em metricas coletadas do seu proprio pipeline.'
+    );
+    // heroTitle nao existe nas traducoes: usa o metaTitle como fallback.
+    expect(resolvedMeta.heroTitle).toBe('MeasureSoftGram');
+    expect(resolvedMeta.ogImage).toBe(meta.ogImage);
+  });
+});


### PR DESCRIPTION
## Problema

A landing page sumiu de produção (msgram.lappis.rocks): a raiz / mostrava só a tela de login. Causa: o commit 5c174e8 ("Revert code to d001f0a") removeu a pasta src/pages/landing/ inteira e repontou a raiz para ./auth.

## O que este PR faz

1. Restaura a landing (src/pages/landing/ + componentes + testes + locales landing.json) e reponta index.page.ts para ./landing/index.page.
2. Corrige o i18n: o n18n.config.js foi recriado depois do revert sem o namespace landing, então as traduções não carregavam e a landing renderizava as chaves cruas (hero.title). Namespace reincluído.

## Validação (Node 20, igual ao CI)

Build local passa, os 17 testes da landing passam, a raiz / responde HTTP 200 com título e meta OG resolvendo no servidor, e os 45 textos i18n carregam sem chave crua.

Não toca no pipeline de deploy (Dockerfile/workflows).
