### PR TITLE
chore(dx): suite deterministica + typecheck + pin do pnpm + .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,26 @@
-SERVICE_URL=http://localhost:8080/api
+# =============================================================================
+# Variaveis de ambiente do Front. Copie para .env e ajuste.
+#
+# Base da API: os services chamam caminhos comecando em /v1 (ex.:
+# `/v1/organizations/`), entao a URL base termina em /api (o resultado final
+# e .../api/v1/...). NAO acrescente /v1 aqui, senao duplica (/api/v1/v1).
+# =============================================================================
+
+# URL da API vista pelo BROWSER (build-time: o Next embute NEXT_PUBLIC_* no
+# bundle do client). Sem ela, o axios fica com baseURL undefined e as chamadas
+# caem no dominio do proprio front (404). Ver src/shared/services/api.ts.
 NEXT_PUBLIC_API_URL=http://localhost:8080/api
+
+# URL da API vista pelo SERVIDOR (Next SSR/API routes). Em dev local aponta pro
+# mesmo host. Rodando via docker-compose-dev, o front fala com o container do
+# Service pela rede do compose - troque por http://service:8080/api (ou
+# http://host.docker.internal:8080/api conforme o setup).
+SERVICE_URL=http://localhost:8080/api
+
+# Callback do OAuth do GitHub: precisa bater com o LOGIN_REDIRECT_URL do
+# Service (o backend usa esse valor como callback_url na troca do code).
 LOGIN_REDIRECT_URL=http://127.0.0.1:3000
+
+# Client ID do mesmo GitHub OAuth App configurado no Service (ver README do
+# Service, secao "Configurar o GitHub OAuth App").
 GITHUB_CLIENT_ID=

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Frontend repository of MeasureSoftGram application in 2026.1.
 ### Local development (without Docker)
 - Node.js `20.x`
 - `corepack` enabled
-- `pnpm` `10.x`
+- `pnpm` `9.0.0` (pin unico em `package.json` `packageManager` e no `Dockerfile`)
 ### Development with Docker
 - Docker
 - Docker Compose v.2
@@ -117,7 +117,7 @@ Primeiramente garanta que está utilizando a versão 20 do Node. Ferramentas par
 
 ```bash
 corepack enable
-corepack prepare pnpm@10.15.0 --activate
+corepack prepare pnpm@9.0.0 --activate
 pnpm -v
 ```
 
@@ -140,14 +140,24 @@ Aplicação disponível em: http://localhost:3000
 ```bash
 pnpm lint
 ```
-- Rodar testes:
+- Rodar testes (watch, so o que mudou - uso local):
 ```bash
 pnpm test
 ```
-- Rodar testes no modo CI:
+- Rodar a suite completa deterministica (mesmo modo do CI, sem reescrever snapshot):
 ```bash
-pnpm run ci:test
+pnpm test:all
 ```
+- Checar tipos (`tsc --noEmit`):
+```bash
+pnpm typecheck
+```
+
+> **Nota sobre o `typecheck`:** hoje o `tsc --noEmit` acusa erros de *parse* nos
+> type defs da `react-i18next` 15.x, que o TypeScript 4.7.4 (pin do projeto) nao
+> consegue ler; nao sao erros do codigo do projeto. Por isso o `typecheck` ainda
+> **nao** e gate bloqueante no CI. Subir o TypeScript pra destravar isso esta
+> rastreado numa issue de follow-up.
 
 - Build de produção:
 ```bash

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "start": "next start",
     "lint": "next lint",
     "test": "TZ=America/Sao_Paulo jest src/ --watch --coverage --verbose --onlyChanged --passWithNoTests",
-    "ci:test": "TZ=America/Sao_Paulo jest --passWithNoTests --updateSnapshot",
+    "test:all": "TZ=America/Sao_Paulo jest --ci --coverage --passWithNoTests",
+    "ci:test": "TZ=America/Sao_Paulo jest --ci --passWithNoTests",
+    "typecheck": "tsc --noEmit",
     "prettier": "prettier --config .prettierrc 'src/**/*.ts' --write",
     "update-snapshot": "TZ=America/Sao_Paulo jest --updateSnapshot"
   },


### PR DESCRIPTION
## Descricao

Resolve os problemas de DX levantados na #66. O gate de tipos no CI ficou como follow-up (#68) por um motivo de toolchain explicado abaixo.

## Mudancas

- **Determinismo dos testes:** `ci:test` agora e `jest --ci` (sem `--updateSnapshot`). Antes o CI reescrevia snapshot silenciosamente, mascarando quebra. Verificado: `jest --ci` verde (102 suites, **523 testes, 57 snapshots**).
- **`test:all`:** `jest --ci --coverage` - suite completa deterministica num script so.
- **`typecheck`:** `tsc --noEmit` adicionado. **Non-blocking no CI por ora** (ver abaixo).
- **Pin do pnpm:** README alinhado pra `9.0.0` (estava `10.x`, divergindo do `packageManager` do `package.json` e do `Dockerfile`, que ja usam 9.0.0 - o CI tambem).
- **`.env.example`:** comentado var a var (build-time `NEXT_PUBLIC_*` vs `SERVICE_URL` do server; base termina em `/api` porque os services ja acrescentam `/v1` - juntar `/api/v1` duplicaria).

## Por que o typecheck nao virou gate de CI agora

`tsc --noEmit` acusa 52 erros de **parse**, **todos** em `node_modules/react-i18next@15.7.4/*.d.ts` - nenhum no codigo do projeto. O TS 4.7.4 (pin do projeto) nao consegue parsear a sintaxe dos type defs da react-i18next 15.x; como sao erros de parse, `skipLibCheck` nao ajuda. Ligar o gate hoje vermelharia todo PR por causa da dependencia. Subir o TS pra destravar isso esta rastreado em **#68**.

## Validacao

- `jest --ci` verde sem `--updateSnapshot` (523/523, 57 snapshots).
- Base da API conferida contra `src/shared/services/*` (chamam `/v1/...`).

Closes #66