### PR TITLE
chore(makefile): make setup + stack completa (dev/up/down)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,18 @@
 DOCKER_COMPOSE ?= docker compose
 SERVICE ?= front
 PNPM_IN_DOCKER = $(DOCKER_COMPOSE) run --rm $(SERVICE) pnpm
+# Stack completa de dev (front + Service + Postgres).
+COMPOSE_DEV = $(DOCKER_COMPOSE) -f docker-compose-dev.yml
+PNPM_VERSION ?= 9.0.0
 
-.PHONY: help build start lint test ci-test prettier update-snapshot pnpm
+.PHONY: help setup dev up down build start lint test ci-test prettier update-snapshot pnpm
 
 help:
 	@echo "Available targets:"
+	@echo "  make setup            # ativa pnpm (corepack), instala deps e cria .env"
+	@echo "  make dev              # sobe a stack completa (front + Service + Postgres) em foreground"
+	@echo "  make up               # sobe a stack completa em background"
+	@echo "  make down             # derruba a stack de dev"
 	@echo "  make build            # executes the build script"
 	@echo "  make start            # executes the start script"
 	@echo "  make lint             # executes the lint script"
@@ -14,6 +21,24 @@ help:
 	@echo "  make prettier         # executes the prettier script"
 	@echo "  make update-snapshot  # executes the update-snapshot script"
 	@echo "  make pnpm SCRIPT=<script> [ARGS=\"...\"]"
+
+# Prepara o ambiente local (host, sem Docker): pnpm via corepack + deps + .env.
+setup:
+	corepack enable
+	corepack prepare pnpm@$(PNPM_VERSION) --activate
+	pnpm install --frozen-lockfile
+	@test -f .env || cp .env.example .env
+	@echo ">>> ambiente pronto. Ajuste .env se precisar e rode 'make dev' (stack completa) ou 'pnpm dev'."
+
+# Sobe front + Service (imagem publicada) + Postgres num comando.
+dev:
+	$(COMPOSE_DEV) up
+
+up:
+	$(COMPOSE_DEV) up -d
+
+down:
+	$(COMPOSE_DEV) down
 
 build:
 	$(PNPM_IN_DOCKER) build

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ pnpm -v
 pnpm install
 ```
 
+> **Atalho:** `make setup` faz os passos 1 e 2 de uma vez (ativa o pnpm via corepack, instala as dependências com `--frozen-lockfile` e cria o `.env` a partir do `.env.example`).
+
 ### 3) Subir o projeto
 
 ```bash
@@ -164,6 +166,21 @@ pnpm typecheck
 pnpm build
 pnpm start
 ```
+
+
+## Rodar com Docker (stack completa)
+
+Para subir o Front junto com o **Service** (imagem publicada) e o **Postgres** num comando só, use o `docker-compose-dev.yml`. Há atalhos no `Makefile`:
+
+```bash
+make dev     # sobe front + Service + Postgres em foreground (com logs)
+make up      # o mesmo, em background (-d)
+make down    # derruba a stack
+```
+
+- Front em <http://localhost:3000>, Service em <http://localhost:8080>.
+- As credenciais do Service/Postgres ficam em `env-vars/.service.env` e `env-vars/.postgres.env` (já versionados com defaults de dev).
+- Para o login com GitHub funcionar, ajuste `GITHUB_CLIENT_ID`/`GITHUB_SECRET` (ver README do Service).
 
 
 ## Troubleshooting


### PR DESCRIPTION
## Descricao

Adiciona targets de onboarding ao Makefile do Front e documenta o `docker-compose-dev.yml` (que sobe front + Service + Postgres) no README.

## Mudancas

- **`make setup`**: ativa o pnpm via corepack (`pnpm@9.0.0`), `pnpm install --frozen-lockfile` e cria `.env` a partir do `.env.example`, num comando (host, sem Docker).
- **`make dev` / `make up` / `make down`**: sobem (foreground / background) e derrubam a **stack completa** de dev (front + Service + Postgres) via `docker-compose-dev.yml`, que ate entao nao era citado no README.
- **README**: atalho `make setup` na secao de setup local + nova secao *Rodar com Docker (stack completa)*.

## Validacao

- `docker compose -f docker-compose-dev.yml config` valido.
- `make help` parseia com os novos targets.
- `make setup`: `pnpm install` e a copia do `.env` OK; o passo `corepack` depende do corepack no PATH (bundled com Node >=16.9, ja e o padrao documentado no README).

Closes #65