### PR TITLE
fix(i18n): corrige namespace lates_value_table para latest_value_table

### DIFF
--- a/src/shared/components/LatestValueTable/LatestValueTable.tsx
+++ b/src/shared/components/LatestValueTable/LatestValueTable.tsx
@@ -25,7 +25,7 @@ interface Prop {
 }
 
 function LatestValueTable({ title, value }: Prop) {
-  const { t } = useTranslation('lates_value_table');
+  const { t } = useTranslation('latest_value_table');
 
   const { data, error, isLoading, isEmpty } = useRequestValues({ type: 'latest-values', value });
   const tableRows: { name: string; latestValue: number; latestData: string }[] = [];


### PR DESCRIPTION
## Motivação

`LatestValueTable` usava `useTranslation('lates_value_table')`  um typo no namespace de i18n. O arquivo de tradução real é `latest_value_table.json` (existe em `public/locales/pt` e `public/locales/en`), então as chaves nunca eram encontradas e o componente caía no fallback (texto cru em vez de traduzido).

## Mudanças

- Corrige o namespace de `lates_value_table` para `latest_value_table` em `LatestValueTable.tsx`

## Status Checklist

- [x] Test
- [x] Lint
- [x] Development

## Screenshots

Correção de string (namespace de i18n), sem mudança de layout — não se aplica.

## Execução

- Acesse qualquer página que renderize a `LatestValueTable` (ex.: Overview de um produto) e confirme que os textos da tabela aparecem traduzidos (pt/en) em vez de cair no fallback.
